### PR TITLE
Sound notifications for various events

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/AlertManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/AlertManager.java
@@ -168,6 +168,7 @@ public class AlertManager {
     public static class AlertConfig {
 
         public boolean enabled = true;
+        public boolean soundOnAlert = true;
         public List<Alert> alerts = new ArrayList<>();
 
         public Option.Builder<Boolean> createEnabledOption() {
@@ -180,8 +181,18 @@ public class AlertManager {
                 .controller(ConfigScreen::createBooleanController);
         }
 
+        public Option.Builder<Boolean> createSoundOnAlertOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Sound - Price Alert"))
+                .description(OptionDescription.of(Component.literal(
+                    "Play a sound when a price alert target is reached.")))
+                .binding(true, () -> this.soundOnAlert, val -> this.soundOnAlert = val)
+                .controller(ConfigScreen::createBooleanController);
+        }
+
         public OptionGroup createGroup() {
-            var rootGroup = new OptionGrouping(this.createEnabledOption());
+            var rootGroup = new OptionGrouping(this.createEnabledOption()).addOptions(this.createSoundOnAlertOption());
 
             return OptionGroup
                 .createBuilder()

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderProtectionManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderProtectionManager.java
@@ -113,9 +113,7 @@ public class OrderProtectionManager {
                     if (cfg.showChatMessage) {
                         sendBlockedOrderMessage(validation);
                     }
-                    if (cfg.soundOnBlocked) {
-                        SoundUtil.playSound(SoundEvents.VILLAGER_NO, 0.6f);
-                    }
+                    SoundUtil.playSoundIf(cfg.soundOnBlocked, SoundEvents.VILLAGER_NO, 0.6f, 1);
                     return true;
                 }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderProtectionManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderProtectionManager.java
@@ -13,6 +13,7 @@ import com.github.lutzluca.btrbz.utils.ScreenActionManager;
 import com.github.lutzluca.btrbz.utils.ScreenActionManager.ScreenClickRule;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
+import com.github.lutzluca.btrbz.utils.SoundUtil;
 import com.github.lutzluca.btrbz.utils.Utils;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.OptionDescription;
@@ -27,6 +28,7 @@ import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
+import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.apache.commons.lang3.tuple.Pair;
@@ -110,6 +112,9 @@ public class OrderProtectionManager {
                 if (isBlocked && !overrideActive) {
                     if (cfg.showChatMessage) {
                         sendBlockedOrderMessage(validation);
+                    }
+                    if (cfg.soundOnBlocked) {
+                        SoundUtil.playSound(SoundEvents.VILLAGER_NO, 0.6f);
                     }
                     return true;
                 }
@@ -334,6 +339,7 @@ public class OrderProtectionManager {
 
         public boolean enabled = true;
         public boolean showChatMessage = true;
+        public boolean soundOnBlocked = true;
 
         public boolean blockUndercutPercentage = true;
         public double maxBuyOrderUndercut = 15.0;
@@ -358,6 +364,16 @@ public class OrderProtectionManager {
                 .description(OptionDescription.of(Component.literal(
                     "Show system chat messages when protections are triggered.")))
                 .binding(true, () -> this.showChatMessage, val -> this.showChatMessage = val)
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        public Option.Builder<Boolean> createSoundOnBlockedOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Sound - Order Blocked"))
+                .description(OptionDescription.of(Component.literal(
+                    "Play a sound when an order is blocked by protection.")))
+                .binding(true, () -> this.soundOnBlocked, val -> this.soundOnBlocked = val)
                 .controller(ConfigScreen::createBooleanController);
         }
 
@@ -432,6 +448,7 @@ public class OrderProtectionManager {
             var rootGroup = new OptionGrouping(this.createEnabledOption())
                 .addOptions(
                     this.createShowChatMessageOption(),
+                    this.createSoundOnBlockedOption(),
                     this.createBlockUndercutOfOpposingOption()
                 )
                 .addSubgroups(undercutGroup);

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -309,12 +309,25 @@ public class TrackedOrderManager {
         public QueueDisplayMode queueDisplayMode = QueueDisplayMode.Both;
 
         public OptionGroup createGroup() {
-            var notifyBestGroup = new OptionGrouping(this.createNotifyBestOption()).addOptions(this.createNotifyBestOnPriorityRegain());
+            var notifyBestGroup = new OptionGrouping(this.createNotifyBestOption())
+                .addOptions(
+                    this.createNotifyBestOnPriorityRegain(),
+                    this.createSoundBestOption()
+                );
 
-            var rootGroup = new OptionGrouping(this.createEnabledOption()).addOptions(
-                this.createGotoMatchedOption(),
-                this.createGotoUndercutOption()
-            ).addSubgroups(notifyBestGroup);
+            var queueGroup = new OptionGrouping(this.createShowQueueInfoOption())
+                .addOptions(this.createQueueDisplayModeOption());
+
+            var rootGroup = new OptionGrouping(this.createEnabledOption())
+                .addOptions(
+                    this.createGotoMatchedOption(),
+                    this.createGotoUndercutOption(),
+                    this.createNotifyMatchedOption(),
+                    this.createSoundMatchedOption(),
+                    this.createNotifyUndercutOption(),
+                    this.createSoundUndercutOption()
+                )
+                .addSubgroups(notifyBestGroup, queueGroup);
 
             return OptionGroup
                 .createBuilder()

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -296,8 +296,11 @@ public class TrackedOrderManager {
 
         public boolean notifyBest = true;
         public boolean onlyOnPriorityRegain = true;
+        public boolean soundBest = true;
         public boolean notifyMatched = true;
+        public boolean soundMatched = true;
         public boolean notifyUndercut = true;
+        public boolean soundUndercut = true;
 
         public Action gotoOnMatched = Action.Order;
         public Action gotoOnUndercut = Action.Order;
@@ -307,14 +310,11 @@ public class TrackedOrderManager {
 
         public OptionGroup createGroup() {
             var notifyBestGroup = new OptionGrouping(this.createNotifyBestOption()).addOptions(this.createNotifyBestOnPriorityRegain());
-            var queueGroup = new OptionGrouping(this.createShowQueueInfoOption()).addOptions(this.createQueueDisplayModeOption());
 
             var rootGroup = new OptionGrouping(this.createEnabledOption()).addOptions(
-                this.createNotifyMatchedOption(),
-                this.createNotifyUndercutOption(),
                 this.createGotoMatchedOption(),
                 this.createGotoUndercutOption()
-            ).addSubgroups(notifyBestGroup, queueGroup);
+            ).addSubgroups(notifyBestGroup);
 
             return OptionGroup
                 .createBuilder()
@@ -422,6 +422,36 @@ public class TrackedOrderManager {
                 .binding(true, () -> this.notifyUndercut, val -> this.notifyUndercut = val)
                 .description(OptionDescription.of(Component.literal(
                     "Send a notification when a tracked order is undercut / outbid by another order")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<Boolean> createSoundBestOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Sound - Best"))
+                .binding(true, () -> this.soundBest, val -> this.soundBest = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Play a sound when a best/top order notification is triggered")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<Boolean> createSoundMatchedOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Sound - Matched"))
+                .binding(true, () -> this.soundMatched, val -> this.soundMatched = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Play a sound when a matched notification is triggered")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<Boolean> createSoundUndercutOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Sound - Undercut"))
+                .binding(true, () -> this.soundUndercut, val -> this.soundUndercut = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Play a sound when an undercut notification is triggered")))
                 .controller(ConfigScreen::createBooleanController);
         }
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -21,6 +21,7 @@ import net.minecraft.network.chat.ClickEvent.RunCommand;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent.ShowText;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.sounds.SoundEvents;
 
 @Slf4j
 public class Notifier {
@@ -51,6 +52,10 @@ public class Notifier {
     }
 
     public static void notifyPriceReached(Alert alert, Optional<Double> price) {
+        if (ConfigManager.get().alert.soundOnAlert) {
+            SoundUtil.notifyMultipleTimes(2, SoundEvents.EXPERIENCE_ORB_PICKUP);
+        }
+        
         String priceText = price
             .map(p -> Utils.formatDecimal(p, 1, true) + " coins. ")
             .orElse("currently has no listed price. ");
@@ -134,24 +139,42 @@ public class Notifier {
                 .withHoverEvent(new ShowText(Component.literal("Run /" + cmd))));
         notifyPlayer(prefix().append(msg.withStyle(ChatFormatting.WHITE)));
     }
-
+    
+    /**
+     * Assumes the parent notification condition (e.g. notifyBest) is already met by the caller.
+     * Only checks the associated sound toggles before playing.
+     */
     public static void notifyOrderStatus(StatusUpdate update) {
         var order = update.trackedOrder();
         var status = update.curr();
 
+        var cfg = ConfigManager.get().trackedOrders;
+
         var msg = switch (status) {
             case Top ignored -> {
+                if (cfg.soundBest) {
+                    SoundUtil.playSound(SoundEvents.NOTE_BLOCK_CHIME, 0.5f);
+                }
                 if (update.prev() instanceof OrderStatus.Unknown) {
                     yield bestMsg(order);
                 }
                 yield reclaimBestMsg(order);
             }
-            case Matched ignored -> matchedMsg(order, update.prev());
-            case Undercut undercut -> undercutMsg(order, undercut.amount);
+            case Matched ignored -> {
+                if (cfg.soundMatched) {
+                    SoundUtil.playSound(SoundEvents.NOTE_BLOCK_CHIME, 0.5f);
+                }
+                yield matchedMsg(order, update.prev());
+            }
+            case Undercut undercut -> {
+                if (cfg.soundUndercut) {
+                    SoundUtil.notifyMultipleTimes(2, SoundEvents.EXPERIENCE_ORB_PICKUP);
+                }
+                yield undercutMsg(order, undercut.amount);
+            }
             default -> throw new IllegalArgumentException("Unreachable curr: " + status);
         };
 
-        var cfg = ConfigManager.get().trackedOrders;
         if (status instanceof Matched && cfg.gotoOnMatched != Action.None) {
             applyGotoAction(msg, cfg.gotoOnMatched, order);
         }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -52,9 +52,7 @@ public class Notifier {
     }
 
     public static void notifyPriceReached(Alert alert, Optional<Double> price) {
-        if (ConfigManager.get().alert.soundOnAlert) {
-            SoundUtil.notifyMultipleTimes(2, SoundEvents.EXPERIENCE_ORB_PICKUP);
-        }
+        SoundUtil.playSoundIf(ConfigManager.get().alert.soundOnAlert, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
         
         String priceText = price
             .map(p -> Utils.formatDecimal(p, 1, true) + " coins. ")
@@ -152,24 +150,18 @@ public class Notifier {
 
         var msg = switch (status) {
             case Top ignored -> {
-                if (cfg.soundBest) {
-                    SoundUtil.playSound(SoundEvents.NOTE_BLOCK_CHIME, 0.5f);
-                }
+                SoundUtil.playSoundIf(cfg.soundBest, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
                 if (update.prev() instanceof OrderStatus.Unknown) {
                     yield bestMsg(order);
                 }
                 yield reclaimBestMsg(order);
             }
             case Matched ignored -> {
-                if (cfg.soundMatched) {
-                    SoundUtil.playSound(SoundEvents.NOTE_BLOCK_CHIME, 0.5f);
-                }
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
                 yield matchedMsg(order, update.prev());
             }
             case Undercut undercut -> {
-                if (cfg.soundUndercut) {
-                    SoundUtil.notifyMultipleTimes(2, SoundEvents.EXPERIENCE_ORB_PICKUP);
-                }
+                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
                 yield undercutMsg(order, undercut.amount);
             }
             default -> throw new IllegalArgumentException("Unreachable curr: " + status);

--- a/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
@@ -13,12 +13,35 @@ public class SoundUtil {
     private static final Map<SoundEvent, Long> lastPlayedTimes = new HashMap<>();
     private static final long SOUND_COOLDOWN_MS = 500L;
 
-    public static void playSound(SoundEvent sound, float volume) {
+    public static void playSoundIf(boolean enabled, SoundEvent sound, float volume, int repeatCount) {
+        if (!enabled) {
+            return;
+        }
+        playSound(sound, volume, repeatCount);
+    }
+
+    public static void playSoundIf(boolean enabled, Holder<SoundEvent> soundEntry, float volume, int repeatCount) {
+        playSoundIf(enabled, soundEntry.value(), volume, repeatCount);
+    }
+
+    public static void playSound(SoundEvent sound, float volume, int repeatCount) {
         long now = System.currentTimeMillis();
         if (now - lastPlayedTimes.getOrDefault(sound, 0L) > SOUND_COOLDOWN_MS) {
             lastPlayedTimes.put(sound, now);
-            play(sound, volume);
+
+            for (int i = 0; i < repeatCount; i++) {
+                if (i == 0) {
+                    play(sound, volume);
+                    continue;
+                }
+
+                ClientTickDispatcher.submit(mc -> play(sound, volume), i * 3);
+            }
         }
+    }
+
+    public static void playSound(SoundEvent sound, float volume) {
+        playSound(sound, volume, 1);
     }
 
     public static void playSound(Holder<SoundEvent> soundEntry, float volume) {
@@ -27,29 +50,12 @@ public class SoundUtil {
 
     private static void play(SoundEvent sound, float volume) {
         Minecraft client = Minecraft.getInstance();
-        if (client.level == null || client.player == null) {
+        if (client.player == null) {
             ClientTickDispatcher.submit(mc -> play(sound, volume), 20);
             return;
         }
 
         SimpleSoundInstance soundInstance = SimpleSoundInstance.forUI(sound, 1f, volume);
         client.getSoundManager().play(soundInstance);
-    }
-
-    public static void notifyMultipleTimes(int notifyNum, SoundEvent sound) {
-        long now = System.currentTimeMillis();
-        if (now - lastPlayedTimes.getOrDefault(sound, 0L) > SOUND_COOLDOWN_MS) {
-            lastPlayedTimes.put(sound, now);
-
-            for (int i = 0; i < notifyNum; i++) {
-                if (i == 0) {
-                    play(sound, 0.5f);
-                    continue;
-                }
-
-                // 20tps = 1/20s = 50ms per tick => ~150ms delay between sounds
-                ClientTickDispatcher.submit(mc -> play(sound, 0.5f), i * 3);
-            }
-        }
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
@@ -1,0 +1,55 @@
+package com.github.lutzluca.btrbz.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.sounds.SimpleSoundInstance;
+import net.minecraft.core.Holder;
+import net.minecraft.sounds.SoundEvent;
+
+@Slf4j
+public class SoundUtil {
+    private static final Map<SoundEvent, Long> lastPlayedTimes = new HashMap<>();
+    private static final long SOUND_COOLDOWN_MS = 500L;
+
+    public static void playSound(SoundEvent sound, float volume) {
+        long now = System.currentTimeMillis();
+        if (now - lastPlayedTimes.getOrDefault(sound, 0L) > SOUND_COOLDOWN_MS) {
+            lastPlayedTimes.put(sound, now);
+            play(sound, volume);
+        }
+    }
+
+    public static void playSound(Holder<SoundEvent> soundEntry, float volume) {
+        playSound(soundEntry.value(), volume);
+    }
+
+    private static void play(SoundEvent sound, float volume) {
+        Minecraft client = Minecraft.getInstance();
+        if (client.level == null || client.player == null) {
+            ClientTickDispatcher.submit(mc -> play(sound, volume), 20);
+            return;
+        }
+
+        SimpleSoundInstance soundInstance = SimpleSoundInstance.forUI(sound, 1f, volume);
+        client.getSoundManager().play(soundInstance);
+    }
+
+    public static void notifyMultipleTimes(int notifyNum, SoundEvent sound) {
+        long now = System.currentTimeMillis();
+        if (now - lastPlayedTimes.getOrDefault(sound, 0L) > SOUND_COOLDOWN_MS) {
+            lastPlayedTimes.put(sound, now);
+
+            for (int i = 0; i < notifyNum; i++) {
+                if (i == 0) {
+                    play(sound, 0.5f);
+                    continue;
+                }
+
+                // 20tps = 1/20s = 50ms per tick => ~150ms delay between sounds
+                ClientTickDispatcher.submit(mc -> play(sound, 0.5f), i * 3);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/SoundUtil.java
@@ -1,7 +1,7 @@
 package com.github.lutzluca.btrbz.utils;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
@@ -10,18 +10,19 @@ import net.minecraft.sounds.SoundEvent;
 
 @Slf4j
 public class SoundUtil {
-    private static final Map<SoundEvent, Long> lastPlayedTimes = new HashMap<>();
+    private static final Map<SoundEvent, Long> lastPlayedTimes = new ConcurrentHashMap<>();
     private static final long SOUND_COOLDOWN_MS = 500L;
+    private static final int MAX_RETRIES = 5;
 
     public static void playSoundIf(boolean enabled, SoundEvent sound, float volume, int repeatCount) {
         if (!enabled) {
             return;
         }
-        playSound(sound, volume, repeatCount);
+        SoundUtil.playSound(sound, volume, repeatCount);
     }
 
     public static void playSoundIf(boolean enabled, Holder<SoundEvent> soundEntry, float volume, int repeatCount) {
-        playSoundIf(enabled, soundEntry.value(), volume, repeatCount);
+        SoundUtil.playSoundIf(enabled, soundEntry.value(), volume, repeatCount);
     }
 
     public static void playSound(SoundEvent sound, float volume, int repeatCount) {
@@ -31,27 +32,33 @@ public class SoundUtil {
 
             for (int i = 0; i < repeatCount; i++) {
                 if (i == 0) {
-                    play(sound, volume);
+                    SoundUtil.play(sound, volume);
                     continue;
                 }
 
-                ClientTickDispatcher.submit(mc -> play(sound, volume), i * 3);
+                ClientTickDispatcher.submit(mc -> SoundUtil.play(sound, volume), i * 3);
             }
         }
     }
 
     public static void playSound(SoundEvent sound, float volume) {
-        playSound(sound, volume, 1);
+        SoundUtil.playSound(sound, volume, 1);
     }
 
     public static void playSound(Holder<SoundEvent> soundEntry, float volume) {
-        playSound(soundEntry.value(), volume);
+        SoundUtil.playSound(soundEntry.value(), volume);
     }
 
     private static void play(SoundEvent sound, float volume) {
+        SoundUtil.play(sound, volume, MAX_RETRIES);
+    }
+
+    private static void play(SoundEvent sound, float volume, int attemptsLeft) {
         Minecraft client = Minecraft.getInstance();
         if (client.player == null) {
-            ClientTickDispatcher.submit(mc -> play(sound, volume), 20);
+            if (attemptsLeft > 0) {
+                ClientTickDispatcher.submit(mc -> SoundUtil.play(sound, volume, attemptsLeft - 1), 20);
+            }
             return;
         }
 


### PR DESCRIPTION
Summary
Adds customizable sound notifications for various events:
- Price Alerts - Sound plays when a price alert target is reached
- Order Protection - Sound plays when an order is blocked by protection settings
- Tracked Orders - Sounds play for:
  - Best position regained
  - Order matched/filled
  - Order undercut
Each sound has a corresponding toggle in the config to enable/disable independently.
Changes
- New SoundUtil utility class for playing Minecraft sounds with cooldown handling
- Added sound options to Alert, OrderProtection, and TrackedOrder configurations
- Config options are exposed in YACL settings screen

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sound notifications for alerts with a toggle in settings.
  * Added configurable sound feedback when orders are blocked.
  * Added configurable sound notifications for tracked order events (best, matched, undercut).
  * Sound playback integrated into price/order notifications.
  * Introduced a sound utility handling playback, cooldowns, retries and repeats for reliable audio feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->