### PR TITLE
feat: display queue info in matched and undercut chat notifications 

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
@@ -135,7 +135,11 @@ public class OrderTooltipProvider {
             queueInfo.ifPresent(orderQueueInfo -> lines.add(Component
                     .literal("Queue: ")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(GameUtils.buildQueueComponent(orderQueueInfo.ordersAhead, orderQueueInfo.itemsAhead))));
+                    .append(GameUtils.buildQueueComponent(
+                        orderQueueInfo.ordersAhead, 
+                        orderQueueInfo.itemsAhead,
+                        ConfigManager.get().trackedOrders.queueDisplayMode
+                    ))));
         }
 
         lines.add(Component.empty());
@@ -176,7 +180,11 @@ public class OrderTooltipProvider {
             queueInfo.ifPresent(orderQueueInfo -> lines.add(Component
                     .literal("Queue: ")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(GameUtils.buildQueueComponent(orderQueueInfo.ordersAhead, orderQueueInfo.itemsAhead))));
+                    .append(GameUtils.buildQueueComponent(
+                        orderQueueInfo.ordersAhead, 
+                        orderQueueInfo.itemsAhead,
+                        ConfigManager.get().trackedOrders.queueDisplayMode
+                    ))));
         }
 
         if (shouldShowPrices(cfg.showPrices, cfg.showOnlyWhenUndercut, order)) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
@@ -135,14 +135,7 @@ public class OrderTooltipProvider {
             queueInfo.ifPresent(orderQueueInfo -> lines.add(Component
                     .literal("Queue: ")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(Component
-                            .literal(String.valueOf(orderQueueInfo.ordersAhead))
-                            .withStyle(ChatFormatting.RED))
-                    .append(Component.literal(" orders (").withStyle(ChatFormatting.GRAY))
-                    .append(Component
-                            .literal(Utils.formatDecimal(orderQueueInfo.itemsAhead, 0, true))
-                            .withStyle(ChatFormatting.RED))
-                    .append(Component.literal(" items)").withStyle(ChatFormatting.GRAY))));
+                    .append(GameUtils.buildQueueComponent(orderQueueInfo.ordersAhead, orderQueueInfo.itemsAhead))));
         }
 
         lines.add(Component.empty());
@@ -183,14 +176,7 @@ public class OrderTooltipProvider {
             queueInfo.ifPresent(orderQueueInfo -> lines.add(Component
                     .literal("Queue: ")
                     .withStyle(ChatFormatting.GRAY)
-                    .append(Component
-                            .literal(String.valueOf(orderQueueInfo.ordersAhead))
-                            .withStyle(ChatFormatting.RED))
-                    .append(Component.literal(" orders (").withStyle(ChatFormatting.GRAY))
-                    .append(Component
-                            .literal(Utils.formatDecimal(orderQueueInfo.itemsAhead, 0, true))
-                            .withStyle(ChatFormatting.RED))
-                    .append(Component.literal(" items)").withStyle(ChatFormatting.GRAY))));
+                    .append(GameUtils.buildQueueComponent(orderQueueInfo.ordersAhead, orderQueueInfo.itemsAhead))));
         }
 
         if (shouldShowPrices(cfg.showPrices, cfg.showOnlyWhenUndercut, order)) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -301,15 +301,19 @@ public class TrackedOrderManager {
         public Action gotoOnMatched = Action.Order;
         public Action gotoOnUndercut = Action.Order;
 
+        public boolean showQueueInfo = true;
+        public QueueDisplayMode queueDisplayMode = QueueDisplayMode.Both;
+
         public OptionGroup createGroup() {
             var notifyBestGroup = new OptionGrouping(this.createNotifyBestOption()).addOptions(this.createNotifyBestOnPriorityRegain());
+            var queueGroup = new OptionGrouping(this.createShowQueueInfoOption()).addOptions(this.createQueueDisplayModeOption());
 
             var rootGroup = new OptionGrouping(this.createEnabledOption()).addOptions(
                 this.createNotifyMatchedOption(),
                 this.createNotifyUndercutOption(),
                 this.createGotoMatchedOption(),
                 this.createGotoUndercutOption()
-            ).addSubgroups(notifyBestGroup);
+            ).addSubgroups(notifyBestGroup, queueGroup);
 
             return OptionGroup
                 .createBuilder()
@@ -347,6 +351,30 @@ public class TrackedOrderManager {
                     action -> this.gotoOnUndercut = action
                 )
                 .controller(Action::controller);
+        }
+
+        private Option.Builder<Boolean> createShowQueueInfoOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Show Queue Info"))
+                .binding(true, () -> this.showQueueInfo, val -> this.showQueueInfo = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Display how many orders/items are ahead of your matched or undercut order")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<QueueDisplayMode> createQueueDisplayModeOption() {
+            return Option
+                .<QueueDisplayMode>createBuilder()
+                .name(Component.literal("Queue Display Mode"))
+                .binding(
+                    QueueDisplayMode.Both,
+                    () -> this.queueDisplayMode != null ? this.queueDisplayMode : QueueDisplayMode.Both,
+                    mode -> this.queueDisplayMode = mode
+                )
+                .description(OptionDescription.of(Component.literal(
+                    "Whether to display the number of orders and items, or just the number of items")))
+                .controller(QueueDisplayMode::controller);
         }
 
         private Option.Builder<Boolean> createNotifyBestOption() {
@@ -416,6 +444,21 @@ public class TrackedOrderManager {
                         case None -> Component.literal("No action");
                         case Item -> Component.literal("Go to Item in Bazaar");
                         case Order -> Component.literal("Open Manage Bazaar Orders");
+                    });
+            }
+        }
+
+        public enum QueueDisplayMode {
+            Both,
+            ItemsOnly;
+
+            public static EnumControllerBuilder<QueueDisplayMode> controller(Option<QueueDisplayMode> option) {
+                return EnumControllerBuilder
+                    .create(option)
+                    .enumClass(QueueDisplayMode.class)
+                    .formatValue(mode -> switch (mode) {
+                        case Both -> Component.literal("Orders and Items");
+                        case ItemsOnly -> Component.literal("Items Only");
                     });
             }
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -1,5 +1,6 @@
 package com.github.lutzluca.btrbz.core;
 
+import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen.OptionGrouping;
@@ -370,7 +371,10 @@ public class TrackedOrderManager {
                 .binding(
                     QueueDisplayMode.Both,
                     () -> this.queueDisplayMode != null ? this.queueDisplayMode : QueueDisplayMode.Both,
-                    mode -> this.queueDisplayMode = mode
+                    mode -> {
+                        this.queueDisplayMode = mode;
+                        BtrBz.tooltipProvider().clearCache();
+                    }
                 )
                 .description(OptionDescription.of(Component.literal(
                     "Whether to display the number of orders and items, or just the number of items")))

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -104,6 +104,13 @@ public class BazaarData {
         String productName, OrderType orderType,
         double pricePerUnit
     ) {
+        return calculateQueuePosition(productName, orderType, pricePerUnit, false);
+    }
+
+    public Optional<OrderQueueInfo> calculateQueuePosition(
+        String productName, OrderType orderType,
+        double pricePerUnit, boolean includeAtPrice
+    ) {
         var productId = this.nameToId(productName);
 
         if (productId.isEmpty()) {
@@ -116,8 +123,10 @@ public class BazaarData {
             return Optional.empty();
         }
 
-        var summaries =
-            orderType == OrderType.Sell ? product.getBuySummary() : product.getSellSummary();
+        var summaries = switch (orderType) {
+            case Sell -> product.getBuySummary();
+            case Buy -> product.getSellSummary();
+        };
 
         if (summaries == null || summaries.isEmpty()) {
             return Optional.empty();
@@ -125,10 +134,13 @@ public class BazaarData {
 
         var queueInfo = new OrderQueueInfo(0, 0);
         for (var summary : summaries) {
-            if (switch (orderType) {
-                case Sell -> summary.getPricePerUnit() >= pricePerUnit;
-                case Buy -> summary.getPricePerUnit() <= pricePerUnit;
-            }) {
+            boolean isSamePrice = summary.getPricePerUnit() == pricePerUnit;
+            boolean isBetter = switch (orderType) {
+                case Sell -> summary.getPricePerUnit() < pricePerUnit;
+                case Buy -> summary.getPricePerUnit() > pricePerUnit;
+            };
+
+            if (!isBetter && !(isSamePrice && includeAtPrice)) {
                 break;
             }
             queueInfo.ordersAhead += (int) summary.getOrders();
@@ -141,7 +153,6 @@ public class BazaarData {
     @ToString
     @AllArgsConstructor
     public static final class OrderQueueInfo {
-
         public int ordersAhead;
         public int itemsAhead;
     }
@@ -149,11 +160,9 @@ public class BazaarData {
     public record OrderPriceInfo(
         Optional<@Nullable Double> buyOrderPrice,
         Optional<@Nullable Double> sellOfferPrice
-    ) {
-    }
+    ) { }
 
-    public record OrderLists(List<Summary> buyOrders, List<Summary> sellOffers) {
-    }
+    public record OrderLists(List<Summary> buyOrders, List<Summary> sellOffers) { }
 
     public static final class TrackedProduct {
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -143,16 +143,16 @@ public final class GameUtils {
 
         if (mode == QueueDisplayMode.ItemsOnly) {
             return Component.literal(Utils.formatDecimal(items, 0, true))
-                .withStyle(ChatFormatting.RED)
-                .append(Component.literal(itemsLabel).withStyle(ChatFormatting.WHITE));
+                .withStyle(ChatFormatting.YELLOW)
+                .append(Component.literal(itemsLabel).withStyle(ChatFormatting.GRAY));
         }
 
         String ordersLabel = orders == 1 ? " order" : " orders";
 
         return Component.literal(String.valueOf(orders))
-            .withStyle(ChatFormatting.RED)
-            .append(Component.literal(ordersLabel + " totalling ").withStyle(ChatFormatting.WHITE))
-            .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(ChatFormatting.RED))
-            .append(Component.literal(itemsLabel).withStyle(ChatFormatting.WHITE));
+            .withStyle(ChatFormatting.YELLOW)
+            .append(Component.literal(ordersLabel + " / ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(ChatFormatting.YELLOW))
+            .append(Component.literal(itemsLabel).withStyle(ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -19,6 +20,7 @@ import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import org.jetbrains.annotations.Nullable;
+import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.QueueDisplayMode;
 
 @Slf4j
 public final class GameUtils {
@@ -136,11 +138,17 @@ public final class GameUtils {
             });
     }
 
-    public static MutableComponent buildQueueComponent(int orders, int items) {
+    public static MutableComponent buildQueueComponent(int orders, int items, QueueDisplayMode mode) {
+        if (mode == QueueDisplayMode.ItemsOnly) {
+            return Component.literal(Utils.formatDecimal(items, 0, true))
+                .withStyle(ChatFormatting.RED)
+                .append(Component.literal(" items").withStyle(ChatFormatting.GRAY));
+        }
+
         return Component.literal(String.valueOf(orders))
-            .withStyle(net.minecraft.ChatFormatting.RED)
-            .append(Component.literal(" orders (").withStyle(net.minecraft.ChatFormatting.GRAY))
-            .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(net.minecraft.ChatFormatting.RED))
-            .append(Component.literal(" items)").withStyle(net.minecraft.ChatFormatting.GRAY));
+            .withStyle(ChatFormatting.RED)
+            .append(Component.literal(" orders (").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(ChatFormatting.RED))
+            .append(Component.literal(" items)").withStyle(ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.scores.DisplaySlot;
@@ -133,5 +134,13 @@ public final class GameUtils {
                     .map(Number::doubleValue)
                     .toJavaOptional();
             });
+    }
+
+    public static MutableComponent buildQueueComponent(int orders, int items) {
+        return Component.literal(String.valueOf(orders))
+            .withStyle(net.minecraft.ChatFormatting.RED)
+            .append(Component.literal(" orders (").withStyle(net.minecraft.ChatFormatting.GRAY))
+            .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(net.minecraft.ChatFormatting.RED))
+            .append(Component.literal(" items)").withStyle(net.minecraft.ChatFormatting.GRAY));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -139,16 +139,20 @@ public final class GameUtils {
     }
 
     public static MutableComponent buildQueueComponent(int orders, int items, QueueDisplayMode mode) {
+        String itemsLabel = items == 1 ? " item" : " items";
+
         if (mode == QueueDisplayMode.ItemsOnly) {
             return Component.literal(Utils.formatDecimal(items, 0, true))
                 .withStyle(ChatFormatting.RED)
-                .append(Component.literal(" items").withStyle(ChatFormatting.GRAY));
+                .append(Component.literal(itemsLabel).withStyle(ChatFormatting.WHITE));
         }
+
+        String ordersLabel = orders == 1 ? " order" : " orders";
 
         return Component.literal(String.valueOf(orders))
             .withStyle(ChatFormatting.RED)
-            .append(Component.literal(" orders (").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(ordersLabel + " totalling ").withStyle(ChatFormatting.WHITE))
             .append(Component.literal(Utils.formatDecimal(items, 0, true)).withStyle(ChatFormatting.RED))
-            .append(Component.literal(" items)").withStyle(ChatFormatting.GRAY));
+            .append(Component.literal(itemsLabel).withStyle(ChatFormatting.WHITE));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -6,9 +6,7 @@ import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.Act
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.StatusUpdate;
 import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.ResolvedAlertArgs;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
-import com.github.lutzluca.btrbz.data.BazaarData.OrderQueueInfo;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus;
-import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.QueueDisplayMode;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Matched;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Top;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Undercut;
@@ -207,7 +205,7 @@ public class Notifier {
         var status = Component
             .empty()
             .append(Component.literal("has been ").withStyle(ChatFormatting.WHITE))
-            .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
+            .append(Component.literal("MATCHED").withStyle(ChatFormatting.BLUE));
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
@@ -215,7 +213,18 @@ public class Notifier {
         if (cfg.showQueueInfo) {
             BtrBz.bazaarData().calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit, true
-            ).ifPresent(info -> appendQueueInfo(msg, info, cfg.queueDisplayMode));
+            ).ifPresent(info -> {
+                int displayOrders = info.ordersAhead - 1;
+                int displayItems = info.itemsAhead - order.volume;
+                if(displayOrders <= 0 || displayItems <= 0) {
+                    log.warn("Invalid queue position for {}: ordersAhead={}, itemsAhead={}, volume={}", 
+                        order, info.ordersAhead, info.itemsAhead, order.volume);
+                    return;
+                }
+                
+                msg.append(Component.literal(" by ").withStyle(ChatFormatting.WHITE));
+                msg.append(GameUtils.buildQueueComponent(displayOrders, displayItems, cfg.queueDisplayMode));
+            });
         }
 
         return msg;
@@ -230,7 +239,7 @@ public class Notifier {
             .append(Component
                 .literal(Utils.formatDecimal(undercutAmount, 1, true))
                 .withStyle(ChatFormatting.GOLD))
-            .append(Component.literal(" coins!").withStyle(ChatFormatting.WHITE));
+            .append(Component.literal(" coins").withStyle(ChatFormatting.WHITE));
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
@@ -238,16 +247,13 @@ public class Notifier {
         if (cfg.showQueueInfo) {
             BtrBz.bazaarData().calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit
-            ).ifPresent(info -> appendQueueInfo(msg, info, cfg.queueDisplayMode));
+            ).ifPresent(info -> {
+                msg.append(Component.literal(", ").withStyle(ChatFormatting.DARK_GRAY));
+                msg.append(GameUtils.buildQueueComponent(info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
+            });
         }
 
         return msg;
-    }
-
-    private static void appendQueueInfo(MutableComponent msg, OrderQueueInfo queueInfo, QueueDisplayMode mode) {
-        msg.append(Component.literal(" [").withStyle(ChatFormatting.DARK_GRAY))
-            .append(GameUtils.buildQueueComponent(queueInfo.ordersAhead, queueInfo.itemsAhead, mode))
-            .append(Component.literal("]").withStyle(ChatFormatting.DARK_GRAY));
     }
 
     public static MutableComponent prefix() {

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -188,7 +188,7 @@ public class Notifier {
     private static MutableComponent bestMsg(TrackedOrder order) {
         var status = Component
             .empty()
-            .append(Component.literal("is the ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("is the ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("BEST Order!").withStyle(ChatFormatting.GREEN));
         return fillBaseMessage(order.type, order.volume, order.productName, status);
     }
@@ -196,7 +196,7 @@ public class Notifier {
     private static MutableComponent reclaimBestMsg(TrackedOrder order) {
         var status = Component
             .empty()
-            .append(Component.literal("has ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("has ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("REGAINED BEST Order!").withStyle(ChatFormatting.GREEN));
         return fillBaseMessage(order.type, order.volume, order.productName, status);
     }
@@ -204,8 +204,8 @@ public class Notifier {
     private static MutableComponent matchedMsg(TrackedOrder order) {
         var status = Component
             .empty()
-            .append(Component.literal("has been ").withStyle(ChatFormatting.WHITE))
-            .append(Component.literal("MATCHED").withStyle(ChatFormatting.BLUE));
+            .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
@@ -214,15 +214,10 @@ public class Notifier {
             BtrBz.bazaarData().calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit, true
             ).ifPresent(info -> {
-                int displayOrders = info.ordersAhead - 1;
-                int displayItems = info.itemsAhead - order.volume;
-                if(displayOrders <= 0 || displayItems <= 0) {
-                    log.warn("Invalid queue position for {}: ordersAhead={}, itemsAhead={}, volume={}", 
-                        order, info.ordersAhead, info.itemsAhead, order.volume);
-                    return;
-                }
-                
-                msg.append(Component.literal(" by ").withStyle(ChatFormatting.WHITE));
+                int displayOrders = Math.max(0, info.ordersAhead - 1);
+                int displayItems = Math.max(0, info.itemsAhead - order.volume);
+
+                msg.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
                 msg.append(GameUtils.buildQueueComponent(displayOrders, displayItems, cfg.queueDisplayMode));
             });
         }
@@ -233,13 +228,13 @@ public class Notifier {
     private static MutableComponent undercutMsg(TrackedOrder order, double undercutAmount) {
         var status = Component
             .empty()
-            .append(Component.literal("has been ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
-            .append(Component.literal("by ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
             .append(Component
                 .literal(Utils.formatDecimal(undercutAmount, 1, true))
                 .withStyle(ChatFormatting.GOLD))
-            .append(Component.literal(" coins").withStyle(ChatFormatting.WHITE));
+            .append(Component.literal(" coins!").withStyle(ChatFormatting.GRAY));
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
@@ -248,7 +243,7 @@ public class Notifier {
             BtrBz.bazaarData().calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit
             ).ifPresent(info -> {
-                msg.append(Component.literal(", ").withStyle(ChatFormatting.DARK_GRAY));
+                msg.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
                 msg.append(GameUtils.buildQueueComponent(info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
             });
         }
@@ -271,13 +266,13 @@ public class Notifier {
             case Sell -> "Sell offer";
         };
         return prefix()
-            .append(Component.literal("Your ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
-            .append(Component.literal(" for ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal(" for ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal(String.valueOf(volume)).withStyle(ChatFormatting.LIGHT_PURPLE))
-            .append(Component.literal("x ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal("x ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal(productName).withStyle(ChatFormatting.YELLOW))
-            .append(Component.literal(" ").withStyle(ChatFormatting.WHITE))
+            .append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
             .append(statusPart);
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -8,6 +8,7 @@ import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.Resolved
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
 import com.github.lutzluca.btrbz.data.BazaarData.OrderQueueInfo;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus;
+import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.QueueDisplayMode;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Matched;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Top;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Undercut;
@@ -210,9 +211,12 @@ public class Notifier {
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
-        BtrBz.bazaarData().calculateQueuePosition(
-            order.productName, order.type, order.pricePerUnit, true
-        ).ifPresent(info -> appendQueueInfo(msg, info));
+        var cfg = ConfigManager.get().trackedOrders;
+        if (cfg.showQueueInfo) {
+            BtrBz.bazaarData().calculateQueuePosition(
+                order.productName, order.type, order.pricePerUnit, true
+            ).ifPresent(info -> appendQueueInfo(msg, info, cfg.queueDisplayMode));
+        }
 
         return msg;
     }
@@ -230,16 +234,19 @@ public class Notifier {
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
-        BtrBz.bazaarData().calculateQueuePosition(
-            order.productName, order.type, order.pricePerUnit
-        ).ifPresent(info -> appendQueueInfo(msg, info));
+        var cfg = ConfigManager.get().trackedOrders;
+        if (cfg.showQueueInfo) {
+            BtrBz.bazaarData().calculateQueuePosition(
+                order.productName, order.type, order.pricePerUnit
+            ).ifPresent(info -> appendQueueInfo(msg, info, cfg.queueDisplayMode));
+        }
 
         return msg;
     }
 
-    private static void appendQueueInfo(MutableComponent msg, OrderQueueInfo queueInfo) {
+    private static void appendQueueInfo(MutableComponent msg, OrderQueueInfo queueInfo, QueueDisplayMode mode) {
         msg.append(Component.literal(" [").withStyle(ChatFormatting.DARK_GRAY))
-            .append(GameUtils.buildQueueComponent(queueInfo.ordersAhead, queueInfo.itemsAhead))
+            .append(GameUtils.buildQueueComponent(queueInfo.ordersAhead, queueInfo.itemsAhead, mode))
             .append(Component.literal("]").withStyle(ChatFormatting.DARK_GRAY));
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -1,10 +1,12 @@
 package com.github.lutzluca.btrbz.utils;
 
+import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.AlertManager.Alert;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.Action;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.StatusUpdate;
 import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.ResolvedAlertArgs;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.data.BazaarData.OrderQueueInfo;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Matched;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Top;
@@ -205,7 +207,14 @@ public class Notifier {
             .empty()
             .append(Component.literal("has been ").withStyle(ChatFormatting.WHITE))
             .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
-        return fillBaseMessage(order.type, order.volume, order.productName, status);
+
+        var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
+
+        BtrBz.bazaarData().calculateQueuePosition(
+            order.productName, order.type, order.pricePerUnit, true
+        ).ifPresent(info -> appendQueueInfo(msg, info));
+
+        return msg;
     }
 
     private static MutableComponent undercutMsg(TrackedOrder order, double undercutAmount) {
@@ -218,7 +227,20 @@ public class Notifier {
                 .literal(Utils.formatDecimal(undercutAmount, 1, true))
                 .withStyle(ChatFormatting.GOLD))
             .append(Component.literal(" coins!").withStyle(ChatFormatting.WHITE));
-        return fillBaseMessage(order.type, order.volume, order.productName, status);
+
+        var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
+
+        BtrBz.bazaarData().calculateQueuePosition(
+            order.productName, order.type, order.pricePerUnit
+        ).ifPresent(info -> appendQueueInfo(msg, info));
+
+        return msg;
+    }
+
+    private static void appendQueueInfo(MutableComponent msg, OrderQueueInfo queueInfo) {
+        msg.append(Component.literal(" [").withStyle(ChatFormatting.DARK_GRAY))
+            .append(GameUtils.buildQueueComponent(queueInfo.ordersAhead, queueInfo.itemsAhead))
+            .append(Component.literal("]").withStyle(ChatFormatting.DARK_GRAY));
     }
 
     public static MutableComponent prefix() {

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -146,7 +146,7 @@ public class Notifier {
                 }
                 yield reclaimBestMsg(order);
             }
-            case Matched ignored -> matchedMsg(order);
+            case Matched ignored -> matchedMsg(order, update.prev());
             case Undercut undercut -> undercutMsg(order, undercut.amount);
             default -> throw new IllegalArgumentException("Unreachable curr: " + status);
         };
@@ -201,7 +201,7 @@ public class Notifier {
         return fillBaseMessage(order.type, order.volume, order.productName, status);
     }
 
-    private static MutableComponent matchedMsg(TrackedOrder order) {
+    private static MutableComponent matchedMsg(TrackedOrder order, OrderStatus prevStatus) {
         var status = Component
             .empty()
             .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
@@ -209,8 +209,12 @@ public class Notifier {
 
         var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
 
+        // Top -> Matched: the player was already the sole best order, so any new same-price
+        // orders arrived after and are behind in the FIFO queue. The API summary only gives
+        // aggregate (orders, volume) per price bucket with no intra-bucket ordering, so
+        // showing them as "ahead" would be misleading. Skip queue info for this transition.
         var cfg = ConfigManager.get().trackedOrders;
-        if (cfg.showQueueInfo) {
+        if (cfg.showQueueInfo && !(prevStatus instanceof OrderStatus.Top)) {
             BtrBz.bazaarData().calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit, true
             ).ifPresent(info -> {


### PR DESCRIPTION
This update refines the Bazaar order notification system with a cleaner, more integrated format and new user configuration options.

### Summary
- **Integrated Queue Info**: "Matched" and "Undercut" messages now contain queue context, showing exactly how many orders and items are ahead.
- **Customization**: Added settings to toggle queue info on/off and switch between showing "Orders and Items" or a compact "Items Only" view.
- **Visual Overhaul**: Refined the color palette to use grays and yellows (not sure If I like the yellow tho)
- **Fix Matched Order Logic**: Updated "Matched" notifications to correctly deduct the user's own order from the queue volume for better accuracy.

<img width="659" height="123" alt="order-items" src="https://github.com/user-attachments/assets/fcac06f0-275e-4677-af72-41129d463db0" />
<img width="661" height="129" alt="items" src="https://github.com/user-attachments/assets/789e4a5e-53ab-4063-b220-a750fca273b8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to show queue position in order notifications
  * New queue display modes: full queue or items-only

* **Improvements**
  * Notifications (matched, undercut, etc.) now append queue position when enabled
  * Tooltips and messages use a unified, consistent queue line format
  * Queue position calculation refined for more accurate placement information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->