### PR TITLE
feat: add estimated fill time tooltips for bazaar orders

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/BazaarOrderActions.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/BazaarOrderActions.java
@@ -241,7 +241,7 @@ public class BazaarOrderActions {
             return;
         }
 
-        remainingOrderAmount = info.volume() - info.filledAmount();
+        remainingOrderAmount = info.volume() - info.filledAmountSnapshot();
         log.debug(
             "Setting remainingOrderAmount to {} from order info {}",
             remainingOrderAmount,

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
@@ -90,17 +90,17 @@ public class OrderTooltipProvider {
                 return;
             }
 
-            var tooltipLines = getCachedTooltip(order, cfg);
+            var tooltipLines = this.getCachedTooltip(order, cfg);
             lines.addAll(1, tooltipLines);
         });
     }
 
     public List<Component> getCachedTooltip(TrackedOrder order, OrderListTooltipConfig cfg) {
-        return this.listCache.getOrCompute(order, () -> buildTooltipLines(order, cfg));
+        return this.listCache.getOrCompute(order, () -> OrderTooltipProvider.buildTooltipLines(order, cfg));
     }
 
     public List<Component> getCachedTooltip(TrackedOrder order, OrderItemTooltipConfig cfg) {
-        return this.itemCache.getOrCompute(order, () -> buildTooltipLines(order, cfg));
+        return this.itemCache.getOrCompute(order, () -> OrderTooltipProvider.buildTooltipLines(order, cfg));
     }
 
     public void clearCache() {
@@ -119,9 +119,9 @@ public class OrderTooltipProvider {
         List<Component> lines = new ArrayList<>();
 
         if (cfg.showStatus) {
-            lines.add(statusLine(order));
+            lines.add(OrderTooltipProvider.statusLine(order));
             if (order.status instanceof OrderStatus.Undercut undercut) {
-                lines.add(undercutAmountLine(undercut.amount));
+                lines.add(OrderTooltipProvider.undercutAmountLine(undercut.amount));
             }
         }
 
@@ -143,11 +143,11 @@ public class OrderTooltipProvider {
         }
 
         lines.add(Component.empty());
-        lines.addAll(currOrderLines(order));
+        lines.addAll(OrderTooltipProvider.currOrderLines(order));
 
-        if (shouldShowPrices(cfg.showPrices, cfg.showOnlyWhenUndercut, order)) {
+        if (OrderTooltipProvider.shouldShowPrices(cfg.showPrices, cfg.showOnlyWhenUndercut, order)) {
             lines.add(Component.empty());
-            lines.addAll(priceLines(data, productId.get()));
+            lines.addAll(OrderTooltipProvider.priceLines(data, productId.get()));
         }
 
         return lines;
@@ -164,9 +164,20 @@ public class OrderTooltipProvider {
         List<Component> lines = new ArrayList<>();
 
         if (cfg.showStatus) {
-            lines.add(statusLine(order));
+            lines.add(OrderTooltipProvider.statusLine(order));
+
+            if (cfg.showEstimatedTime && order.status instanceof OrderStatus.Top) {
+                int remainingVolume = order.volume - order.fillAmountSnapshot;
+
+                data.getEstimatedFillTimeMinutes(order.productName, order.type, remainingVolume).ifPresent(minutes -> {
+                    var time = Component.literal(Utils.formatDuration(minutes)).withStyle(ChatFormatting.YELLOW);
+                    var line = Component.literal("Estimated fill time: ").withStyle(ChatFormatting.GRAY).append(time);
+                    lines.add(line);
+                });
+            }
+
             if (order.status instanceof OrderStatus.Undercut undercut) {
-                lines.add(undercutAmountLine(undercut.amount));
+                lines.add(OrderTooltipProvider.undercutAmountLine(undercut.amount));
             }
         }
 
@@ -202,6 +213,7 @@ public class OrderTooltipProvider {
         if (!showOnlyWhenUndercut) {
             return true;
         }
+
         return order.status instanceof OrderStatus.Undercut;
     }
 
@@ -365,6 +377,7 @@ public class OrderTooltipProvider {
         public boolean showQueue = true;
         public boolean showPrices = false;
         public boolean showOnlyWhenUndercut = true;
+        public boolean showEstimatedTime = false;
 
         private static void invalidateCache() {
             BtrBz.tooltipProvider().clearCache();
@@ -425,6 +438,17 @@ public class OrderTooltipProvider {
                 .controller(ConfigScreen::createBooleanController);
         }
 
+        public Option.Builder<Boolean> createEstimatedTimeOption() {
+            return Option.<Boolean>createBuilder()
+                .name(Component.literal("Show Estimated Fill Time"))
+                .binding(false, () -> this.showEstimatedTime, val -> {
+                    this.showEstimatedTime = val;
+                    invalidateCache();
+                })
+                .description(OptionDescription.of(Component.literal("Show the estimated time to fill the order, based on the Bazaar's moving week volume. Only shown if the order is top priority.")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
         public OptionGroup createGroup() {
             var pricesGroup = new OptionGrouping(this.createPricesOption())
                 .addOptions(this.createOnlyWhenUndercutOption());
@@ -432,7 +456,8 @@ public class OrderTooltipProvider {
             var root = new OptionGrouping(this.createEnabledOption())
                 .addOptions(
                     this.createStatusOption(),
-                    this.createQueueOption()
+                    this.createQueueOption(),
+                    this.createEstimatedTimeOption()
                 )
                 .addSubgroups(pricesGroup);
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
@@ -445,7 +445,13 @@ public class OrderTooltipProvider {
                     this.showEstimatedTime = val;
                     invalidateCache();
                 })
-                .description(OptionDescription.of(Component.literal("Show the estimated time to fill the order, based on the Bazaar's moving week volume. Only shown if the order is top priority.")))
+                .description(OptionDescription.of(Component.literal(
+                    "Show a rough, opt-in estimate of how long a top-priority order might take to fill. " +
+                    "Calculated as: Remaining Volume / (Weekly Moving Volume / 10,080 minutes). " +
+                    "This time may be significantly off, as it uses a weekly volume average that won't reflect recent market shifts, " +
+                    "and the filled amount is a UI snapshot that may lag behind the actual server state. " +
+                    "Only shown for top orders. Treat this as a ballpark guess, not a reliable countdown."
+                )))
                 .controller(ConfigScreen::createBooleanController);
         }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -102,6 +102,7 @@ public class TrackedOrderManager {
                 info -> {
                     unfilledCopy.remove(info);
                     tracked.slot = info.slotIdx();
+                    tracked.fillAmountSnapshot = info.filledAmountSnapshot();
                 }, () -> toRemove.add(tracked)
             );
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
@@ -86,7 +86,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
 
         if (this.unfilledOrders != null) {
             for (var order : this.unfilledOrders) {
-                int unfilledVolume = order.volume() - order.filledAmount();
+                int unfilledVolume = order.volume() - order.filledAmountSnapshot();
 
                 switch (order.type()) {
                     case Buy -> {

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -150,6 +150,37 @@ public class BazaarData {
         return queueInfo.ordersAhead > 0 ? Optional.of(queueInfo) : Optional.empty();
     }
 
+    public Optional<Double> getEstimatedFillTimeMinutes(String productName, OrderType orderType, int remainingVolume) {
+        if (remainingVolume <= 0) {
+            return Optional.of(0.0);
+        }
+
+        var productId = this.nameToId(productName);
+        if (productId.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var product = this.lastProducts.get(productId.get());
+        if (product == null) {
+            return Optional.empty();
+        }
+
+        var qs = product.getQuickStatus();
+        long movingWeek = switch (orderType) {
+            case Sell -> qs.getBuyMovingWeek();
+            case Buy -> qs.getSellMovingWeek();
+        };
+
+        if (movingWeek <= 0) {
+            return Optional.empty();
+        }
+
+        double hourlyRate = movingWeek / 168.0;
+        double minutesRate = hourlyRate / 60.0;
+
+        return Optional.of(remainingVolume / minutesRate);
+    }
+
     @ToString
     @AllArgsConstructor
     public static final class OrderQueueInfo {

--- a/src/main/java/com/github/lutzluca/btrbz/data/OrderModels.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/OrderModels.java
@@ -43,7 +43,7 @@ public final class OrderModels {
 
         int slotIdx();
 
-        int filledAmount();
+        int filledAmountSnapshot();
 
         int unclaimed();
 
@@ -52,7 +52,7 @@ public final class OrderModels {
             OrderType type,
             int volume,
             double pricePerUnit,
-            int filledAmount,
+            int filledAmountSnapshot,
             int unclaimed,
             int slotIdx
         ) implements OrderInfo { }
@@ -62,7 +62,7 @@ public final class OrderModels {
             OrderType type,
             int volume,
             double pricePerUnit,
-            int filledAmount,
+            int filledAmountSnapshot,
             int unclaimed,
             int slotIdx
         ) implements OrderInfo { }
@@ -110,7 +110,12 @@ public final class OrderModels {
         public final double pricePerUnit;
         public OrderStatus status = new OrderStatus.Unknown();
         public int slot;
-
+        /**
+         * The amount of items that were filled at the time this order was last viewed in the Bazaar UI.
+         * This value is a snapshot from the UI and may differ from the actual Bazaar state.
+         * It should ONLY be used for UI-side heuristics like the estimated fill time feature.
+         */
+        public int fillAmountSnapshot;
 
         public TrackedOrder(OrderInfo.UnfilledOrderInfo info) {
             this.productName = info.productName;
@@ -118,6 +123,7 @@ public final class OrderModels {
             this.volume = info.volume;
             this.pricePerUnit = info.pricePerUnit;
             this.slot = info.slotIdx;
+            this.fillAmountSnapshot = info.filledAmountSnapshot;
         }
 
         public TrackedOrder(OutstandingOrderInfo info) {
@@ -126,6 +132,7 @@ public final class OrderModels {
             this.volume = info.volume;
             this.pricePerUnit = info.pricePerUnit;
             this.slot = -1;
+            this.fillAmountSnapshot = 0;
         }
 
         public boolean matches(OrderInfo info) {

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
@@ -176,4 +176,23 @@ public final class Utils {
 
         return ret.toString();
     }
+
+    public static String formatDuration(double totalMinutes) {
+        if (totalMinutes < 1) {
+            return "< 1m";
+        }
+
+        long hours = (long) (totalMinutes / 60);
+        long minutes = (long) (totalMinutes % 60);
+
+        if (hours > 0) {
+            if (minutes > 0) {
+                return String.format("%dh %dm", hours, minutes);
+            }
+
+            return String.format("%dh", hours);
+        }
+
+        return String.format("%dm", minutes);
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds an opt-in estimated time-to-fill indicator for active Bazaar orders. The indicator is designed as a rough ballpark based on historical weekly volume trends and should not be treated as a precise prediction.

## Why it's opt-in
The feature is disabled by default because it is a simplified heuristic with the following caveats:

- **Snapshot divergence**: The filled amount used in the calculation is retrieved from the Minecraft UI at the time the Bazaar screen is viewed. Since the UI typically refreshes in ~20s intervals, the `fillAmountSnapshot` can lag behind the actual server state. If other orders partially fill in the background, the "remaining volume" will be too high, leading to an overly pessimistic estimate.
- **Weekly averages vs current conditions**: The moving-week volume smooths over daily and hourly spikes. If the market for an item shifted recently, the estimate may be significantly inaccurate (e.g., showing 5m when the fill takes hours).
- **Top orders only**: The estimate is only displayed when the user holds the best price position. Under-cutting dynamics (queue depth, competing trader frequency) are too complex to model accurately without more sophisticated tracking.
- **No live tracking**: The estimate only recalculates when Bazaar API data refreshes and the tooltip cache is cleared.

## Implementation details
- **BazaarData**: Added `getEstimatedFillTimeMinutes()` utilizing the Hypixel API's `buyMovingWeek` / `sellMovingWeek` fields from `Product.QuickStatus`.
- **OrderModels**: Extended `TrackedOrder` and related records to include `fillAmountSnapshot`.
- **TrackedOrderManager**: Logic to update `fillAmountSnapshot` when syncing orders from the UI.
- **Utils**: Added `formatDuration()` to provide human-readable strings (e.g., `2h 15m`, `45m`, `< 1m`).
- **OrderTooltipProvider**: Integrated the tooltip line and added the YACL configuration toggle.

## Configuration
The feature can be enabled via **Config → Order Item Tooltips → Show Estimated Fill Time**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Estimated Fill Time feature for orders, displaying predicted completion times based on current market activity and volume rates

* **Improvements**
  * Enhanced accuracy of remaining order amount calculations for better unfilled volume tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->