### PR TITLE
refactor: unify product context and enable Order Book support across setup flow

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -14,6 +14,7 @@ import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
 import com.github.lutzluca.btrbz.utils.Utils;
+import java.util.Set;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.Option.Builder;
 import dev.isxander.yacl3.api.OptionDescription;
@@ -45,6 +46,20 @@ public final class ProductInfoProvider {
 
     private static final int CUSTOM_ITEM_IDX = 22;
     private static final int PRODUCT_IDX = 13;
+
+    /**
+     * Screens that are part of the product order flow. The opened product info
+     * is preserved when transitioning between these screens.
+     */
+    private static final Set<BazaarMenuType> PRODUCT_FLOW_MENUS = Set.of(
+        BazaarMenuType.Item,
+        BazaarMenuType.BuyOrderSetupVolume,
+        BazaarMenuType.BuyOrderSetupPrice,
+        BazaarMenuType.BuyOrderConfirmation,
+        BazaarMenuType.SellOfferSetup,
+        BazaarMenuType.SellOfferConfirmation
+    );
+
 
     private static ProductInfoProvider instance;
     private final PriceCache priceCache;
@@ -119,18 +134,37 @@ public final class ProductInfoProvider {
             }
         );
 
-        ScreenInfoHelper.registerOnClose(
-            ignored -> true, ignored -> {
-                if (this.openedProductNameInfo != null) {
-                    log.debug(
-                        "Closing product: {} ({})",
-                        this.openedProductNameInfo.productName,
-                        this.openedProductNameInfo.productId
-                    );
-                }
+        ScreenInfoHelper.registerOnSwitch(curr -> {
+            if (this.openedProductNameInfo == null) {
+                return;
+            }
+
+            var prev = ScreenInfoHelper.get().getPrevInfo();
+            boolean prevInFlow = prev.inMenu(PRODUCT_FLOW_MENUS.toArray(BazaarMenuType[]::new));
+
+            if (!prevInFlow) {
+                // do we need this?
+                this.openedProductNameInfo = null;
+                return;
+            }
+
+            // Only clear when navigating to a known non-flow bazaar screen or closing
+            // entirely. Transient screens (e.g. OrderBookScreen, SignEditScreen, or other
+            // injected screens) are implicitly preserved since they don't match any
+            // BazaarMenuType
+            boolean closed = curr.getScreen() == null;
+            boolean leftToNonFlowBazaar = curr.inBazaar()
+                && !curr.inMenu(PRODUCT_FLOW_MENUS.toArray(BazaarMenuType[]::new));
+
+            if (closed || leftToNonFlowBazaar) {
+                log.debug(
+                    "Leaving product flow, clearing product: {} ({})",
+                    this.openedProductNameInfo.productName,
+                    this.openedProductNameInfo.productId
+                );
                 this.openedProductNameInfo = null;
             }
-        );
+        });
     }
 
     private void registerInfoProviderItemOverride() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -139,15 +139,6 @@ public final class ProductInfoProvider {
                 return;
             }
 
-            var prev = ScreenInfoHelper.get().getPrevInfo();
-            boolean prevInFlow = prev.inMenu(PRODUCT_FLOW_MENUS.toArray(BazaarMenuType[]::new));
-
-            if (!prevInFlow) {
-                // do we need this?
-                this.openedProductNameInfo = null;
-                return;
-            }
-
             // Only clear when navigating to a known non-flow bazaar screen or closing
             // entirely. Transient screens (e.g. OrderBookScreen, SignEditScreen, or other
             // injected screens) are implicitly preserved since they don't match any
@@ -173,7 +164,11 @@ public final class ProductInfoProvider {
             if (!cfg.enabled || !cfg.itemClickEnabled) {
                 return Optional.empty();
             }
-            if (this.openedProductNameInfo == null || slot.getContainerSlot() != CUSTOM_ITEM_IDX) {
+
+            if (this.openedProductNameInfo == null ||
+                slot.getContainerSlot() != CUSTOM_ITEM_IDX ||
+                !info.inMenu(BazaarMenuType.Item)
+            ) {
                 return Optional.empty();
             }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -49,7 +49,7 @@ public final class ProductInfoProvider {
 
     /**
      * Screens that are part of the product order flow. The opened product info
-     * is preserved when transitioning between these screens.
+     * is preserved when transitioning between these screens
      */
     private static final Set<BazaarMenuType> PRODUCT_FLOW_MENUS = Set.of(
         BazaarMenuType.Item,
@@ -60,6 +60,7 @@ public final class ProductInfoProvider {
         BazaarMenuType.SellOfferConfirmation
     );
 
+    private static final BazaarMenuType[] PRODUCT_FLOW_MENUS_ARRAY = PRODUCT_FLOW_MENUS.toArray(BazaarMenuType[]::new);
 
     private static ProductInfoProvider instance;
     private final PriceCache priceCache;
@@ -145,7 +146,7 @@ public final class ProductInfoProvider {
             // BazaarMenuType
             boolean closed = curr.getScreen() == null;
             boolean leftToNonFlowBazaar = curr.inBazaar()
-                && !curr.inMenu(PRODUCT_FLOW_MENUS.toArray(BazaarMenuType[]::new));
+                && !curr.inMenu(PRODUCT_FLOW_MENUS_ARRAY);
 
             if (closed || leftToNonFlowBazaar) {
                 log.debug(

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.modules.orderpreset;
 
 import com.github.lutzluca.btrbz.BtrBz;
+import com.github.lutzluca.btrbz.core.ProductInfoProvider;
 import com.github.lutzluca.btrbz.core.modules.Module;
 import com.github.lutzluca.btrbz.data.OrderInfoParser;
 
@@ -31,13 +32,11 @@ import org.jetbrains.annotations.Nullable;
 @Slf4j
 public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
+
     private ListWidget list;
     private int currMaxVolume = GameUtils.GLOBAL_MAX_ORDER_VOLUME;
 
-    // TODO: combine `openedProductId` with ProductInfoProvider's state for `openedProductId`
-    // expose the `openedProductId` of the ProductInfoProver and keep state across order
-    // transaction flow (the menus associated with it)
-    private @Nullable String currProductId = null;
+    // Tracks the buy order transaction flow (volume → price → confirmation)
     private int pendingVolume = -1;
     private boolean pendingPreset = false;
     private boolean inTransaction = false;
@@ -51,13 +50,6 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
             var prev = ScreenInfoHelper.get().getPrevInfo();
 
             if (curr.inMenu(BazaarMenuType.BuyOrderSetupVolume) && prev.inMenu(BazaarMenuType.Item)) {
-                this.currProductId = prev
-                    .getItemStack(13)
-                    .map(ItemStack::getHoverName)
-                    .map(Component::getString)
-                    .flatMap(BtrBz.bazaarData()::nameToId)
-                    .orElse(null);
-
                 this.currMaxVolume = curr
                     .getItemStack(16)
                     .flatMap(this::getMaxVolume)
@@ -65,8 +57,8 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
                 this.inTransaction = true;
                 log.debug(
-                    "Starting transaction for resolved product '{}' with maxVolume '{}'",
-                    this.currProductId,
+                    "Starting buy order transaction for product '{}' with maxVolume '{}'",
+                    this.getCurrentProductId(),
                     this.currMaxVolume
                 );
 
@@ -88,8 +80,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
             if (this.inTransaction && (!isOrderFlowMenu && !isOrderFlowSignScreen)) {
                 log.debug(
-                    "Canceling transaction for resolved product '{}': prev={}, curr={}",
-                    this.currProductId,
+                    "Canceling buy order transaction: prev={}, curr={}",
                     prev.getMenuType(),
                     curr.getMenuType()
                 );
@@ -141,14 +132,18 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
     }
 
     public void cancelTransaction() {
-        log.debug("Ending transaction for product '{}'", this.currProductId);
+        log.debug("Ending buy order transaction");
         this.inTransaction = false;
 
         this.pendingVolume = -1;
         this.pendingPreset = false;
 
         this.currMaxVolume = GameUtils.GLOBAL_MAX_ORDER_VOLUME;
-        this.currProductId = null;
+    }
+
+    private @Nullable String getCurrentProductId() {
+        var info = ProductInfoProvider.get().getOpenedProductNameInfo();
+        return info != null ? info.productId() : null;
     }
 
     private boolean isOrderFlowSignScreen(ScreenInfo curr, ScreenInfo prev) {
@@ -165,7 +160,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
         var purse = GameUtils.getPurse();
         var pricePerUnit = Optional
-            .ofNullable(this.currProductId)
+            .ofNullable(this.getCurrentProductId())
             .flatMap(BtrBz.bazaarData()::highestBuyPrice)
             .map(price -> price + .1);
         var priceAvailable = pricePerUnit.isPresent();
@@ -363,14 +358,15 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
         int volume = switch (preset) {
             case OrderPreset.Max ignored -> {
-                if (this.currProductId == null) {
+                var productId = this.getCurrentProductId();
+                if (productId == null) {
                     log.debug("Cannot calculate MAX: product ID unavailable");
                     yield 0;
                 }
 
                 var price = BtrBz
                     .bazaarData()
-                    .highestBuyPrice(this.currProductId)
+                    .highestBuyPrice(productId)
                     .map(currPrice -> currPrice + 0.1);
 
                 if (price.isEmpty()) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/order_book/OrderBookScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/order_book/OrderBookScreen.java
@@ -11,6 +11,7 @@ import com.github.lutzluca.btrbz.widgets.Renderable;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product.Summary;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
 
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.gui.screens.Screen;
@@ -32,6 +33,8 @@ public class OrderBookScreen extends Screen {
 
     @Override
     protected void init() {
+        super.init();
+
         int width = this.width;
         int height = this.height;
 
@@ -41,7 +44,7 @@ public class OrderBookScreen extends Screen {
         int panelY = (height - panelHeight) / 2;
 
         int listWidth = (panelWidth - 30) / 2;
-        int listHeight = panelHeight - 60;
+        int listHeight = panelHeight - 90;
 
         int buyX = panelX + 10;
         int listY = panelY + 40;
@@ -97,6 +100,18 @@ public class OrderBookScreen extends Screen {
 
         this.widgetManager = new WidgetManager(List.of(buyOrderList, sellOfferList));
         this.widgetManager.init();
+
+        int buttonWidth = 100;
+        int buttonHeight = 20;
+        int buttonX = panelX + (panelWidth - buttonWidth) / 2;
+        int buttonY = listY + listHeight + 15;
+
+        // TODO: eventually replace with custom button?
+        this.addRenderableWidget(
+            Button.builder(Component.literal("Go Back"), btn -> this.onClose())
+                .bounds(buttonX, buttonY, buttonWidth, buttonHeight)
+                .build()
+        );
     }
 
     private void copyPriceToClipboard(double price) {
@@ -109,17 +124,33 @@ public class OrderBookScreen extends Screen {
     }
 
     @Override
+    public void renderBackground(GuiGraphics context, int mouseX, int mouseY, float delta) {
+        // suppress vanilla background rendering so it does not cover the custom background
+    }
+
+    @Override
     public void render(GuiGraphics context, int mouseX, int mouseY, float delta) {
         context.fill(0, 0, this.width, this.height, 0x80000000);
 
+        super.render(context, mouseX, mouseY, delta);
+
         int listY = (this.height - (int) (this.height * 0.8)) / 2 + 40;
 
-        context.drawString(
+        context.drawCenteredString(
             this.font,
             this.title,
-            (this.width - this.font.width(this.title)) / 2,
+            this.width / 2,
             listY - 30,
-            0xFFFFFF
+            0xFFFFFFFF
+        );
+
+        Component subtitle = Component.literal("Click an order to copy its price");
+        context.drawCenteredString(
+            this.font,
+            subtitle,
+            this.width / 2,
+            listY - 15,
+            0xFFAAAAAA
         );
 
         this.widgetManager.render(context, mouseX, mouseY, delta);

--- a/src/main/java/com/github/lutzluca/btrbz/core/order_book/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/order_book/OrderBookScreenController.java
@@ -27,9 +27,18 @@ public class OrderBookScreenController {
     private static final int CUSTOM_ORDER_BOOK_IDX = 8;
     private static OrderBookScreenController instance;
 
+    private static boolean isOrderSetupMenu(ScreenInfo info) {
+        return info.inMenu(
+            BazaarMenuType.Item,
+            BazaarMenuType.BuyOrderSetupVolume,
+            BazaarMenuType.BuyOrderSetupPrice,
+            BazaarMenuType.SellOfferSetup
+        );
+    }
+
     private OrderBookScreenController() {
         ItemOverrideManager.register((info, slot, original) -> {
-            if (slot.getContainerSlot() != CUSTOM_ORDER_BOOK_IDX || !info.inMenu(BazaarMenuType.Item)) {
+            if (slot.getContainerSlot() != CUSTOM_ORDER_BOOK_IDX || !isOrderSetupMenu(info)) {
                 return Optional.empty();
             }
             if (GameUtils.isPlayerInventorySlot(slot)) {
@@ -53,7 +62,9 @@ public class OrderBookScreenController {
 
             @Override
             public boolean applies(ScreenInfo info, Slot slot, int button) {
-                return slot.getContainerSlot() == CUSTOM_ORDER_BOOK_IDX && info.inMenu(BazaarMenuType.Item) && ConfigManager.get().orderBook.enabled;
+                return slot.getContainerSlot() == CUSTOM_ORDER_BOOK_IDX && 
+                    isOrderSetupMenu(info) && 
+                    ConfigManager.get().orderBook.enabled;
             }
 
             @Override


### PR DESCRIPTION
**Summary**
This PR centralizes Bazaar product tracking and ensures that the "opened product" context persists across the entire order transaction flow. By moving from a strict screen-based lifecycle to a flow-based lifecycle, we enable features like the **Order Book** and **Order Presets** to remain functional throughout buy/sell setup menus, sign-edit screens, and custom mod interfaces, while enabling the OrderBook to be available for different menus not only the `BuyOrderSetupVolume`.

**Key Changes**
*   **Flow-Aware Context Persistence**: Refactored `ProductInfoProvider` to preserve the active product ID during transitions within the order flow. It now only clears the context when explicitly leaving for a non-flow Bazaar menu or closing the screen entirely.
*   **Order Book Expansion**: Enabled the "Open Order Book" button in the **Buy Order Setup (Volume/Price)** and **Sell Offer Setup** menus. 
* **Order Book Render Issues**: The `OrderBookScreen` now displays the associated Product as well as a "Go Back" button and information about the click to copy the price functionality
*   **Architectural Consolidation**: Removed duplicate product resolution logic from `OrderPresetsModule`. The module now consumes the centralized state from `ProductInfoProvider`, resolving a long-standing TODO.
*   **Transient Screen Support**: Improved navigation logic to implicitly support custom screens (like the Order Book) and `SignEditScreen` without losing the active product context (not sure if that is really a improvement, but this allows for some wiggle room).

**Future Improvements**
* Could have a option to show the OrderBook (buy order and sell offer lists) inside the setup price for the product - need to be careful to always use the latest data from the API (update the lists with a `BtrBz.bazaarData().onUpdate(...)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Go Back" button to close the order book screen.

* **Improvements**
  * Preserves opened product info when navigating between product-order-flow screens.
  * Order presets now derive the current opened product dynamically.
  * Item override availability limited to the item/order-setup context.
  * Order book visuals: centered title/subtitle, tighter layout, custom background retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->