### PR TITLE
feat: adding relevant order list to enter price screen

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
+++ b/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
@@ -13,6 +13,7 @@ import com.github.lutzluca.btrbz.core.TrackedOrderManager;
 import com.github.lutzluca.btrbz.core.commands.Commands;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
 import com.github.lutzluca.btrbz.core.modules.BookmarkModule;
+import com.github.lutzluca.btrbz.core.modules.OrderBookPriceModule;
 import com.github.lutzluca.btrbz.core.modules.OrderLimitModule;
 import com.github.lutzluca.btrbz.core.modules.orderpreset.OrderPresetsModule;
 import com.github.lutzluca.btrbz.core.modules.OrderValueModule;
@@ -124,6 +125,7 @@ public class BtrBz implements ClientModInitializer {
         moduleManager.registerModule(OrderPresetsModule.class);
         var orderLimitModule = moduleManager.registerModule(OrderLimitModule.class);
         var orderValueModule = moduleManager.registerModule(OrderValueModule.class);
+        moduleManager.registerModule(OrderBookPriceModule.class);
 
         this.orderManager.afterOrderSync((unfilledOrders, filledOrder) -> {
             var trackedOrders = this.orderManager.getTrackedOrders();

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -113,11 +113,6 @@ public final class ProductInfoProvider {
     private void registerProductInfoListener() {
         ScreenInfoHelper.registerOnLoaded(
             info -> info.inMenu(BazaarMenuType.Item), (info, inv) -> {
-                var cfg = ConfigManager.get().productInfo;
-                if (!cfg.enabled) {
-                    return;
-                }
-
                 var productName = inv
                     .getItem(PRODUCT_IDX)
                     .map(ItemStack::getHoverName)

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -32,6 +32,7 @@ import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConfirmLinkScreen;
+import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.Slot;
@@ -140,13 +141,25 @@ public final class ProductInfoProvider {
                 return;
             }
 
+            var prev = ScreenInfoHelper.get().getPrevInfo();
+
             // Only clear when navigating to a known non-flow bazaar screen or closing
             // entirely. Transient screens (e.g. OrderBookScreen, SignEditScreen, or other
             // injected screens) are implicitly preserved since they don't match any
             // BazaarMenuType
             boolean closed = curr.getScreen() == null;
+            boolean transientFlowClose = closed && prev.getScreen() instanceof SignEditScreen;
             boolean leftToNonFlowBazaar = curr.inBazaar()
                 && !curr.inMenu(PRODUCT_FLOW_MENUS_ARRAY);
+
+            if (transientFlowClose) {
+                log.debug(
+                    "Preserving product context on transient flow close: {} ({})",
+                    this.openedProductNameInfo.productName,
+                    this.openedProductNameInfo.productId
+                );
+                return;
+            }
 
             if (closed || leftToNonFlowBazaar) {
                 log.debug(

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/Config.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/Config.java
@@ -20,6 +20,8 @@ import com.github.lutzluca.btrbz.core.modules.OrderValueModule;
 import com.github.lutzluca.btrbz.core.modules.OrderValueModule.OrderValueOverlayConfig;
 import com.github.lutzluca.btrbz.core.modules.PriceDiffModule;
 import com.github.lutzluca.btrbz.core.modules.PriceDiffModule.PriceDiffConfig;
+import com.github.lutzluca.btrbz.core.modules.OrderBookPriceModule;
+import com.github.lutzluca.btrbz.core.modules.OrderBookPriceModule.OrderBookPriceConfig;
 import com.github.lutzluca.btrbz.core.modules.TrackedOrdersListModule;
 import com.github.lutzluca.btrbz.core.modules.TrackedOrdersListModule.OrderListConfig;
 import com.github.lutzluca.btrbz.core.order_book.OrderBookScreenController.OrderBookConfig;
@@ -52,6 +54,10 @@ public class Config {
     @SerialEntry
     @BindModule(OrderPresetsModule.class)
     public OrderPresetsConfig orderPresets = new OrderPresetsConfig();
+
+    @SerialEntry
+    @BindModule(OrderBookPriceModule.class)
+    public OrderBookPriceConfig orderBookPrice = new OrderBookPriceConfig();
 
     @SerialEntry
     public ProductInfoProviderConfig productInfo = new ProductInfoProviderConfig();

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
@@ -56,6 +56,7 @@ public class ConfigScreen {
             .group(config.orderHighlight.createGroup())
             .group(config.flipHelper.createGroup())
             .group(config.orderPresets.createGroup())
+            .group(config.orderBookPrice.createGroup())
             .group(config.orderValueOverlay.createGroup())
             .group(config.orderProtection.createGroup())
             .group(config.orderBook.createGroup())

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -1,0 +1,631 @@
+package com.github.lutzluca.btrbz.core.modules;
+
+import com.github.lutzluca.btrbz.BtrBz;
+import com.github.lutzluca.btrbz.core.ProductInfoProvider;
+import com.github.lutzluca.btrbz.core.config.ConfigScreen;
+import com.github.lutzluca.btrbz.core.config.ConfigScreen.OptionGrouping;
+import com.github.lutzluca.btrbz.core.order_book.OrderBookScreen.OrderBookRenderable;
+import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
+import com.github.lutzluca.btrbz.utils.GameUtils;
+import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
+import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
+import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
+import com.github.lutzluca.btrbz.utils.Utils;
+import com.github.lutzluca.btrbz.widgets.ListWidget;
+import com.github.lutzluca.btrbz.widgets.Renderable;
+import com.github.lutzluca.btrbz.widgets.base.DraggableWidget;
+import com.github.lutzluca.btrbz.widgets.base.RenderContext;
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.OptionDescription;
+import dev.isxander.yacl3.api.OptionGroup;
+import dev.isxander.yacl3.api.controller.EnumControllerBuilder;
+import lombok.extern.slf4j.Slf4j;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.inventory.SignEditScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.inventory.ClickType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+@Slf4j
+public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookPriceConfig> {
+
+    private static final int PRICE_SETUP_SIGN_TRIGGER_SLOT = 16;
+
+    private OrderBookPriceWidget widget;
+
+    // Transaction state
+    private double pendingPrice = -1;
+    private boolean pendingSubmit = false;
+    @Nullable private OrderType currentOrderType;
+
+    @Override
+    public void onLoad() {
+        ScreenInfoHelper.registerOnSwitch(curr -> {
+            if (!this.configState.enabled || this.configState.displayMode == DisplayMode.Off) {
+                return;
+            }
+
+            var prev = ScreenInfoHelper.get().getPrevInfo();
+            this.refreshCurrentOrderType(curr, prev);
+
+            if (this.isContainerPriceScreen(curr)) {
+                this.rebuildLists();
+            }
+
+            if (!this.isPriceScreen(curr)) {
+                if (this.pendingSubmit || this.pendingPrice >= 0 || this.currentOrderType != null) {
+                    log.debug(
+                        "Clearing stale overlay state: prev={}, curr={}",
+                        prev.getMenuType(),
+                        curr.getMenuType()
+                    );
+                }
+
+                this.pendingPrice = -1;
+                this.pendingSubmit = false;
+                this.currentOrderType = null;
+            }
+        });
+
+        ScreenInfoHelper.registerOnSwitch(info -> {
+            if (!this.configState.enabled) {
+                return;
+            }
+
+            if (this.getCurrentProductId() == null) {
+                return;
+            }
+
+            if (!(info.getScreen() instanceof SignEditScreen signEditScreen)) {
+                return;
+            }
+
+            if (!this.pendingSubmit || this.pendingPrice < 0) {
+                return;
+            }
+
+            // Submit price directly to the sign
+            String priceStr = Utils.formatDecimal(this.pendingPrice, 1, false);
+            GameUtils.submitSignValue(signEditScreen, priceStr);
+
+            this.pendingPrice = -1;
+            this.pendingSubmit = false;
+        });
+        
+        // Also listen for data updates so order lists refresh
+        BtrBz.bazaarData().addListener(products -> {
+            if (this.isDisplayed() && this.getCurrentProductId() != null) {
+                this.rebuildLists();
+            }
+        });
+    }
+
+    private @Nullable String getCurrentProductId() {
+        var info = ProductInfoProvider.get().getOpenedProductNameInfo();
+        return info != null ? info.productId() : null;
+    }
+
+    private boolean isContainerPriceScreen(ScreenInfo info) {
+        return info.inMenu(BazaarMenuType.BuyOrderSetupPrice, BazaarMenuType.SellOfferSetup);
+    }
+
+    private boolean isSignPriceScreen(ScreenInfo info) {
+        return info.getScreen() instanceof SignEditScreen && this.getCurrentProductId() != null;
+    }
+
+    private boolean isPriceScreen(ScreenInfo info) {
+        return this.isContainerPriceScreen(info) || this.isSignPriceScreen(info);
+    }
+
+    private Optional<OrderType> resolveCurrentOrderType(ScreenInfo curr, ScreenInfo prev) {
+        if (curr.inMenu(BazaarMenuType.BuyOrderSetupPrice) ||
+            (curr.getScreen() instanceof SignEditScreen && prev.inMenu(BazaarMenuType.BuyOrderSetupPrice))) {
+            return Optional.of(OrderType.Buy);
+        }
+
+        if (curr.inMenu(BazaarMenuType.SellOfferSetup) ||
+            (curr.getScreen() instanceof SignEditScreen && prev.inMenu(BazaarMenuType.SellOfferSetup))) {
+            return Optional.of(OrderType.Sell);
+        }
+
+        return Optional.empty();
+    }
+
+    private void refreshCurrentOrderType(ScreenInfo curr, ScreenInfo prev) {
+        this.resolveCurrentOrderType(curr, prev).ifPresent(orderType -> this.currentOrderType = orderType);
+    }
+
+    public enum PriceScreen {
+        Container,
+        Sign
+    }
+
+    private Optional<PriceScreen> getPriceScreen(ScreenInfo info) {
+        if (this.isContainerPriceScreen(info)) {
+            return Optional.of(PriceScreen.Container);
+        }
+
+        if (this.isSignPriceScreen(info)) {
+            return Optional.of(PriceScreen.Sign);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean shouldDisplay(ScreenInfo info) {
+        if (!this.configState.enabled || this.configState.displayMode == DisplayMode.Off) {
+            return false;
+        }
+
+        return this.getCurrentProductId() != null && this.getPriceScreen(info).isPresent();
+    }
+
+    public void rebuildLists() {
+        if (this.widget == null) {
+            return;
+        }
+
+        var productId = this.getCurrentProductId();
+        if (productId == null) {
+            return;
+        }
+
+        if (this.configState.displayMode == DisplayMode.Relevant && this.currentOrderType == null) {
+            return;
+        }
+
+        var orders = BtrBz.bazaarData().getOrderLists(productId);
+
+        List<Renderable> buyWidgets = new ArrayList<>();
+        for (var summary : orders.buyOrders()) {
+            buyWidgets.add(new OrderBookRenderable(summary, OrderType.Buy));
+        }
+
+        List<Renderable> sellWidgets = new ArrayList<>();
+        for (var summary : orders.sellOffers()) {
+            sellWidgets.add(new OrderBookRenderable(summary, OrderType.Sell));
+        }
+
+        boolean showBuy = switch (this.configState.displayMode) {
+            case Relevant -> this.currentOrderType == OrderType.Buy;
+            case Both -> true;
+            case Off -> false;
+        };
+
+        boolean showSell = switch (this.configState.displayMode) {
+            case Relevant -> this.currentOrderType == OrderType.Sell;
+            case Both -> true;
+            case Off -> false;
+        };
+
+        this.widget.updateLists(showBuy, buyWidgets, showSell, sellWidgets, this.configState.clickMode);
+    }
+
+    @Override
+    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+        var screen = this.getPriceScreen(info);
+        if (screen.isEmpty()) {
+            return List.of();
+        }
+
+        var bounds = info
+            .getHandledScreenBounds()
+            .or(() -> ScreenInfoHelper.get().getPrevInfo().getHandledScreenBounds());
+
+        if (bounds.isEmpty()) {
+            return List.of();
+        }
+
+        int x = bounds.get().x();
+        int y = 0;
+        int width = bounds.get().width();
+        int height = Math.max(bounds.get().y(), 0);
+
+        if (this.widget == null) {
+            this.widget = new OrderBookPriceWidget(
+                x,
+                y,
+                width,
+                height,
+                this.configState.clickMode,
+                mode -> this.updateConfig(cfg -> cfg.clickMode = mode),
+                this::handlePriceClick
+            );
+            this.widget.setDraggable(false);
+        } else {
+            this.widget.setX(x);
+            this.widget.setY(y);
+            this.widget.setOverlayBounds(width, height);
+            this.widget.setMode(this.configState.clickMode);
+        }
+
+        this.rebuildLists();
+        return List.of(this.widget);
+    }
+
+    private void handlePriceClick(double rawPrice, boolean copyOnly) {
+        if (this.getCurrentProductId() == null) {
+            return;
+        }
+
+        var currInfo = ScreenInfoHelper.get().getCurrInfo();
+        var prevInfo = ScreenInfoHelper.get().getPrevInfo();
+        var orderType = this.resolveCurrentOrderType(currInfo, prevInfo).orElse(this.currentOrderType);
+        if (orderType == null) {
+            return;
+        }
+
+        this.currentOrderType = orderType;
+
+        ClickMode mode = this.widget.getMode();
+        double priceToUse = rawPrice;
+
+        if (mode == ClickMode.Undercut) {
+            switch (orderType) {
+                case Buy -> priceToUse = rawPrice + 0.1;
+                case Sell -> priceToUse = Math.max(rawPrice - 0.1, 0.1);
+            }
+        }
+        
+        if (copyOnly) {
+            GameUtils.copyToClipboard(Utils.formatDecimal(priceToUse, 1, false));
+            return;
+        }
+
+        var client = Minecraft.getInstance();
+        var player = client.player;
+        var interactionManager = client.gameMode;
+        if (player == null || interactionManager == null) {
+            return;
+        }
+
+        this.pendingSubmit = true;
+        this.pendingPrice = priceToUse;
+
+        log.debug("Price click processed: rawPrice={}, finalPrice={}, mode={}", rawPrice, priceToUse, mode);
+
+        if (currInfo.getScreen() instanceof SignEditScreen signEditScreen) {
+            GameUtils.submitSignValue(signEditScreen, Utils.formatDecimal(priceToUse, 1, false));
+
+            this.pendingPrice = -1;
+            this.pendingSubmit = false;
+            return;
+        }
+
+        interactionManager.handleInventoryMouseClick(
+            currInfo.getGenericContainerScreen().get().getMenu().containerId, PRICE_SETUP_SIGN_TRIGGER_SLOT, 1, ClickType.PICKUP, player
+        );
+    }
+
+    public enum DisplayMode {
+        Relevant,
+        Both,
+        Off;
+
+        public static EnumControllerBuilder<DisplayMode> controller(Option<DisplayMode> option) {
+            return EnumControllerBuilder
+                .create(option)
+                .enumClass(DisplayMode.class)
+                .formatValue(mode -> switch (mode) {
+                    case Relevant -> Component.literal("Relevant Only");
+                    case Both -> Component.literal("Both");
+                    case Off -> Component.literal("Off");
+                });
+        }
+    }
+
+    public enum ClickMode {
+        Copy,
+        Undercut;
+
+        public static EnumControllerBuilder<ClickMode> controller(Option<ClickMode> option) {
+            return EnumControllerBuilder
+                .create(option)
+                .enumClass(ClickMode.class)
+                .formatValue(mode -> switch (mode) {
+                    case Copy -> Component.literal("Copy Price");
+                    case Undercut -> Component.literal("Undercut (±0.1)");
+                });
+        }
+    }
+
+    public static class OrderBookPriceConfig {
+        public boolean enabled = true;
+        public DisplayMode displayMode = DisplayMode.Relevant;
+        public ClickMode clickMode = ClickMode.Undercut;
+
+        public Option.Builder<Boolean> createEnableOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.nullToEmpty("Order Book Price Overlay: Master Switch"))
+                .description(OptionDescription.of(Component.literal(
+                    "Master switch to enable or disable the Order Book overlay on price entry screens.")))
+                .binding(true, () -> this.enabled, val -> this.enabled = val)
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        public Option.Builder<DisplayMode> createDisplayModeOption() {
+            return Option
+                .<DisplayMode>createBuilder()
+                .name(Component.nullToEmpty("Display Mode"))
+                .description(OptionDescription.of(Component.literal(
+                    "Which order lists to show on the overlay.")))
+                .binding(
+                    DisplayMode.Relevant,
+                    () -> this.displayMode != null ? this.displayMode : DisplayMode.Relevant,
+                    val -> this.displayMode = val
+                )
+                .controller(DisplayMode::controller);
+        }
+
+        public Option.Builder<ClickMode> createClickModeOption() {
+            return Option
+                .<ClickMode>createBuilder()
+                .name(Component.nullToEmpty("Default Click Mode"))
+                .description(OptionDescription.of(Component.literal(
+                    "Default behaviour when clicking an order entry. Can also be toggled in the widget.")))
+                .binding(
+                    ClickMode.Undercut,
+                    () -> this.clickMode != null ? this.clickMode : ClickMode.Undercut,
+                    val -> this.clickMode = val
+                )
+                .controller(ClickMode::controller);
+        }
+
+        public OptionGroup createGroup() {
+            var rootGroup = new OptionGrouping(this.createEnableOption())
+                .addOptions(
+                    this.createDisplayModeOption(),
+                    this.createClickModeOption()
+                );
+
+            return OptionGroup
+                .createBuilder()
+                .name(Component.nullToEmpty("Order Book Price Overlay"))
+                .description(OptionDescription.of(Component.literal(
+                    "Displays order book data over the price entry sign/menu.")))
+                .options(rootGroup.build())
+                .collapsed(false)
+                .build();
+        }
+    }
+
+    @FunctionalInterface
+    public interface PriceClickHandler {
+        void onClick(double rawPrice, boolean copyOnly);
+    }
+
+    private static class OrderBookPriceWidget extends DraggableWidget {
+        private static final int HEADER_HEIGHT = 16;
+        private static final int LABEL_HEIGHT = 14;
+        private static final int BUTTON_HEIGHT = 16;
+        private static final int CONTROLS_HEIGHT = LABEL_HEIGHT + BUTTON_HEIGHT;
+        private static final int LIST_Y_OFFSET = HEADER_HEIGHT + CONTROLS_HEIGHT;
+        private static final int LIST_GAP = 5;
+        private static final int MIN_LIST_WIDTH = 80;
+        private static final int MIN_LIST_HEIGHT = 30;
+
+        private final ListWidget buyList;
+        private final ListWidget sellList;
+        private final Button modeToggleButton;
+        
+        private ClickMode currentMode;
+        private final Consumer<ClickMode> onModeChanged;
+        
+        private boolean showBuy;
+        private boolean showSell;
+
+        private int listWidth;
+        private int listHeight;
+
+        public OrderBookPriceWidget(
+            int defaultX,
+            int defaultY,
+            int width,
+            int height,
+            ClickMode initialMode,
+            Consumer<ClickMode> onModeChanged,
+            PriceClickHandler onClickHandler
+        ) {
+            super(defaultX, defaultY, width, height);
+            this.currentMode = initialMode;
+            this.onModeChanged = onModeChanged;
+
+            this.listWidth = Math.max((width - LIST_GAP) / 2, MIN_LIST_WIDTH);
+            this.listHeight = Math.max(height - LIST_Y_OFFSET, MIN_LIST_HEIGHT);
+
+            // Mode toggle button spans the width at the top (under drag handle area + label)
+            this.modeToggleButton = Button.builder(
+                this.getModeButtonText(initialMode),
+                btn -> this.toggleMode()
+            ).bounds(0, HEADER_HEIGHT + LABEL_HEIGHT, width, BUTTON_HEIGHT).build();
+
+            this.buyList = new ListWidget(0, LIST_Y_OFFSET, this.listWidth, this.listHeight, "Buy Orders");
+            this.buyList.setStatic().setDraggable(false);
+            this.buyList.setItemHeight(14);
+            this.buyList.onItemClick((self, renderable, index) -> {
+                if (renderable instanceof OrderBookRenderable br) {
+                    boolean copyOnly = Minecraft.getInstance().hasShiftDown() || Minecraft.getInstance().hasControlDown();
+                    onClickHandler.onClick(br.getPricePerUnit(), copyOnly);
+                }
+            });
+
+            this.sellList = new ListWidget(0, LIST_Y_OFFSET, this.listWidth, this.listHeight, "Sell Offers");
+            this.sellList.setStatic().setDraggable(false);
+            this.sellList.setItemHeight(14);
+            this.sellList.onItemClick((self, renderable, index) -> {
+                if (renderable instanceof OrderBookRenderable br) {
+                    boolean copyOnly = Minecraft.getInstance().hasShiftDown() || Minecraft.getInstance().hasControlDown();
+                    onClickHandler.onClick(br.getPricePerUnit(), copyOnly);
+                }
+            });
+
+            this.setDraggable(false);
+            this.setOverlayBounds(width, height);
+        }
+
+        public void setOverlayBounds(int width, int height) {
+            this.width = Math.max(width, MIN_LIST_WIDTH);
+            this.height = Math.max(height, LIST_Y_OFFSET + MIN_LIST_HEIGHT);
+
+            this.modeToggleButton.setWidth(this.width);
+            this.updateChildLayout();
+            this.updateChildPositions();
+        }
+        
+        public ClickMode getMode() {
+            return this.currentMode;
+        }
+
+        public void setMode(ClickMode mode) {
+            this.currentMode = mode;
+            this.modeToggleButton.setMessage(this.getModeButtonText(mode));
+        }
+
+        private void toggleMode() {
+            this.currentMode = this.currentMode == ClickMode.Copy ? ClickMode.Undercut : ClickMode.Copy;
+            this.modeToggleButton.setMessage(this.getModeButtonText(this.currentMode));
+            this.onModeChanged.accept(this.currentMode);
+        }
+
+        private Component getModeButtonText(ClickMode mode) {
+            return Component.literal(mode == ClickMode.Copy ? "[Switch to Undercut]" : "[Switch to Copy]")
+                .withStyle(mode == ClickMode.Copy ? ChatFormatting.GOLD : ChatFormatting.AQUA);
+        }
+
+        private Component getModeInstruction() {
+            if (this.currentMode == ClickMode.Copy) {
+                return Component.literal("L-Click: Copy Price").withStyle(ChatFormatting.AQUA);
+            } else {
+                return Component.literal("L-Click: Undercut Price").withStyle(ChatFormatting.GOLD);
+            }
+        }
+
+        public void updateLists(boolean showBuy, List<Renderable> buyItems, boolean showSell, List<Renderable> sellItems, ClickMode mode) {
+            this.showBuy = showBuy;
+            this.showSell = showSell;
+            this.buyList.setItems(buyItems);
+            this.sellList.setItems(sellItems);
+            this.setMode(mode);
+
+            this.updateChildLayout();
+            this.updateChildPositions();
+        }
+
+        @Override
+        public void setX(int x) {
+            super.setX(x);
+            this.updateChildPositions();
+        }
+
+        @Override
+        public void setY(int y) {
+            super.setY(y);
+            this.updateChildPositions();
+        }
+
+        private void updateChildLayout() {
+            int visibleColumns = (this.showBuy ? 1 : 0) + (this.showSell ? 1 : 0);
+            if (visibleColumns <= 0) {
+                this.listWidth = Math.max(this.width, MIN_LIST_WIDTH);
+            } else {
+                int gap = visibleColumns > 1 ? LIST_GAP : 0;
+                this.listWidth = Math.max((this.width - gap) / visibleColumns, MIN_LIST_WIDTH);
+            }
+
+            this.listHeight = Math.max(this.height - LIST_Y_OFFSET, MIN_LIST_HEIGHT);
+
+            this.buyList.setWidth(this.listWidth);
+            this.buyList.setHeight(this.listHeight);
+            this.sellList.setWidth(this.listWidth);
+            this.sellList.setHeight(this.listHeight);
+        }
+
+        private void updateChildPositions() {
+            this.modeToggleButton.setX(this.getX());
+            this.modeToggleButton.setY(this.getY() + HEADER_HEIGHT + LABEL_HEIGHT);
+
+            int curX = this.getX();
+            if (this.showBuy) {
+                this.buyList.setX(curX);
+                if (this.showSell) {
+                    curX += this.listWidth + LIST_GAP;
+                }
+            }
+            if (this.showSell) {
+                this.sellList.setX(curX);
+            }
+
+            this.buyList.setY(this.getY() + LIST_Y_OFFSET);
+            this.sellList.setY(this.getY() + LIST_Y_OFFSET);
+        }
+
+        @Override
+        protected void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta, RenderContext ctx) {
+            // Main Widget Header
+            graphics.fill(this.getX(), this.getY(), this.getX() + this.width, this.getY() + HEADER_HEIGHT, 0xC0000000);
+            graphics.drawCenteredString(Minecraft.getInstance().font, "Order Book", this.getX() + this.width / 2, this.getY() + 4, 0xFFFFFFFF);
+
+            // Controls area background
+            graphics.fill(this.getX(), this.getY() + HEADER_HEIGHT, this.getX() + this.width, this.getY() + LIST_Y_OFFSET, 0x80000000);
+            
+            // Instructions Label
+            graphics.drawCenteredString(Minecraft.getInstance().font, this.getModeInstruction(), this.getX() + this.width / 2, this.getY() + HEADER_HEIGHT + 3, 0xFFDDDDDD);
+
+            this.modeToggleButton.render(graphics, mouseX, mouseY, delta);
+
+            if (this.showBuy) this.buyList.render(graphics, mouseX, mouseY, delta);
+            if (this.showSell) this.sellList.render(graphics, mouseX, mouseY, delta);
+        }
+
+        @Override
+        public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
+            if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseClicked(event, doubleClick)) {
+                return true;
+            }
+            if (this.showBuy && this.buyList.isMouseOver(event.x(), event.y()) && this.buyList.mouseClicked(event, doubleClick)) return true;
+            if (this.showSell && this.sellList.isMouseOver(event.x(), event.y()) && this.sellList.mouseClicked(event, doubleClick)) return true;
+            return super.mouseClicked(event, doubleClick);
+        }
+
+        @Override
+        public boolean mouseReleased(MouseButtonEvent event) {
+            if (this.isDragging()) {
+                return super.mouseReleased(event);
+            }
+            if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseReleased(event)) {
+                return true;
+            }
+            if (this.showBuy && this.buyList.mouseReleased(event)) return true;
+            if (this.showSell && this.sellList.mouseReleased(event)) return true;
+            return super.mouseReleased(event);
+        }
+
+        @Override
+        public boolean mouseDragged(MouseButtonEvent event, double deltaX, double deltaY) {
+            if (this.isDragging()) {
+                return super.mouseDragged(event, deltaX, deltaY);
+            }
+            if (this.showBuy && this.buyList.isMouseOver(event.x(), event.y()) && this.buyList.mouseDragged(event, deltaX, deltaY)) return true;
+            if (this.showSell && this.sellList.isMouseOver(event.x(), event.y()) && this.sellList.mouseDragged(event, deltaX, deltaY)) return true;
+            return super.mouseDragged(event, deltaX, deltaY);
+        }
+
+        @Override
+        public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+            if (this.showBuy && this.buyList.isMouseOver(mouseX, mouseY) && this.buyList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) return true;
+            if (this.showSell && this.sellList.isMouseOver(mouseX, mouseY) && this.sellList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) return true;
+            return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+        }
+    }
+}

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -6,6 +6,7 @@ import com.github.lutzluca.btrbz.core.config.ConfigScreen;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen.OptionGrouping;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
 import com.github.lutzluca.btrbz.utils.GameUtils;
+import com.github.lutzluca.btrbz.utils.Notifier;
 import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
@@ -18,12 +19,10 @@ import com.github.lutzluca.btrbz.widgets.base.RenderContext;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.OptionDescription;
 import dev.isxander.yacl3.api.OptionGroup;
-import dev.isxander.yacl3.api.controller.EnumControllerBuilder;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
@@ -34,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 @Slf4j
 public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookPriceConfig> {
@@ -153,12 +151,11 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         if (this.currentOrderType == null) {
             log.debug("Current order type is null, clearing list for product {}", productNameInfo.productName());
-            this.widget.updateList(List.of(), this.configState.clickMode);
+            this.widget.updateList(List.of());
             return;
         }
 
         var orders = BtrBz.bazaarData().getOrderLists(productNameInfo.productId());
-        var productName = productNameInfo.productName();
 
         var summaries = switch (this.currentOrderType) {
             case Buy -> orders.buyOrders();
@@ -167,10 +164,10 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         List<Renderable> entries = new ArrayList<>();
         for (var summary : summaries) {
-            entries.add(new OrderBookEntry(productName, summary, this.currentOrderType));
+            entries.add(new OrderBookEntry(summary, this.currentOrderType));
         }
 
-        this.widget.updateList(entries, this.configState.clickMode);
+        this.widget.updateList(entries);
     }
 
     @Override
@@ -190,14 +187,10 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             this.widget = new OrderBookPriceWidget(
                 position.map(Position::x).orElse(20),
                 position.map(Position::y).orElse(20),
-                this.configState.clickMode,
-                mode -> this.updateConfig(cfg -> cfg.clickMode = mode),
                 this::handlePriceClick
             );
 
             this.widget.onDragEnd((self, pos) -> this.savePosition(pos));
-        } else {
-            this.widget.setMode(this.configState.clickMode);
         }
 
         this.widget.setDraggable(true);
@@ -233,18 +226,16 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
 
         this.currentOrderType = orderType;
-        ClickMode mode = this.widget.getMode();
-        double priceToUse = rawPrice;
-
-        if (mode == ClickMode.Undercut) {
-            switch (orderType) {
-                case Buy -> priceToUse = rawPrice + 0.1;
-                case Sell -> priceToUse = Math.max(rawPrice - 0.1, 0.1);
-            }
-        }
+        double priceToUse = this.applyUndercut(rawPrice, orderType);
 
         if (copyOnly) {
-            GameUtils.copyToClipboard(Utils.formatDecimal(priceToUse, 1, false));
+            String formattedPrice = Utils.formatDecimal(priceToUse, 1, false);
+            GameUtils.copyToClipboard(formattedPrice);
+            Notifier.notifyPlayer(Notifier
+                .prefix()
+                .append(Component.literal("Copied price ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(formattedPrice).withStyle(ChatFormatting.AQUA, ChatFormatting.BOLD))
+                .append(Component.literal(" to clipboard").withStyle(ChatFormatting.GRAY)));
             return;
         }
 
@@ -258,7 +249,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         this.pendingSubmit = true;
         this.pendingPrice = priceToUse;
 
-        log.debug("Price click processed: rawPrice={}, finalPrice={}, mode={}", rawPrice, priceToUse, mode);
+        log.debug("Price click processed: rawPrice={}, finalPrice={}", rawPrice, priceToUse);
 
         if (currInfo.getScreen() instanceof SignEditScreen signEditScreen) {
             GameUtils.submitSignValue(signEditScreen, Utils.formatDecimal(priceToUse, 1, false));
@@ -273,26 +264,17 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         );
     }
 
-    public enum ClickMode {
-        Matched,
-        Undercut;
-
-        public static EnumControllerBuilder<ClickMode> controller(Option<ClickMode> option) {
-            return EnumControllerBuilder
-                .create(option)
-                .enumClass(ClickMode.class)
-                .formatValue(mode -> switch (mode) {
-                    case Matched -> Component.literal("Copy Price");
-                    case Undercut -> Component.literal("Undercut (±0.1)");
-                });
-        }
+    private double applyUndercut(double rawPrice, OrderType orderType) {
+        return switch (orderType) {
+            case Buy -> rawPrice + 0.1;
+            case Sell -> Math.max(rawPrice - 0.1, 0.1);
+        };
     }
 
     public static class OrderBookPriceConfig {
         public Integer signX;
         public Integer signY;
         public boolean enabled = true;
-        public ClickMode clickMode = ClickMode.Undercut;
 
         public Option.Builder<Boolean> createEnableOption() {
             return Option
@@ -304,23 +286,8 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 .controller(ConfigScreen::createBooleanController);
         }
 
-        public Option.Builder<ClickMode> createClickModeOption() {
-            return Option
-                .<ClickMode>createBuilder()
-                .name(Component.nullToEmpty("Default Click Mode"))
-                .description(OptionDescription.of(Component.literal(
-                    "Default behaviour when clicking an order entry. Can also be toggled in the widget.")))
-                .binding(
-                    ClickMode.Undercut,
-                    () -> this.clickMode != null ? this.clickMode : ClickMode.Undercut,
-                    val -> this.clickMode = val
-                )
-                .controller(ClickMode::controller);
-        }
-
         public OptionGroup createGroup() {
-            var rootGroup = new OptionGrouping(this.createEnableOption())
-                .addOptions(this.createClickModeOption());
+            var rootGroup = new OptionGrouping(this.createEnableOption());
 
             return OptionGroup
                 .createBuilder()
@@ -344,7 +311,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         private final Component priceText;
         private final Component statsText;
 
-        public OrderBookEntry(String productName, Summary summary, OrderType type) {
+        public OrderBookEntry(Summary summary, OrderType type) {
             this.summary = summary;
             this.type = type;
             this.priceText = Component.literal(Utils.formatDecimal(summary.getPricePerUnit(), 1, true));
@@ -383,96 +350,79 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
     }
 
-    // it should be explained why we have this here with all the forwarding of the 
-    // callbacks
     private static class OrderBookPriceWidget extends DraggableWidget {
         private static final int HEADER_HEIGHT = 16;
-        private static final int LABEL_HEIGHT = 14;
-        private static final int BUTTON_HEIGHT = 16;
-        private static final int CONTROLS_HEIGHT = LABEL_HEIGHT + BUTTON_HEIGHT;
-        private static final int LIST_Y_OFFSET = HEADER_HEIGHT + CONTROLS_HEIGHT;
+        private static final int INSTRUCTION_HEIGHT = 14;
+        private static final int LIST_Y_OFFSET = HEADER_HEIGHT + INSTRUCTION_HEIGHT;
         private static final int ITEM_HEIGHT = 16;
 
         private static final int DEFAULT_WIDTH = 280;
         private static final int DEFAULT_HEIGHT = 220;
 
+        private static final int HEADER_BACKGROUND_COLOR = 0xC0000000;
+        private static final int INSTRUCTION_BACKGROUND_COLOR = 0x80000000;
+        private static final int TITLE_COLOR = 0xFFFFFFFF;
+        private static final int INSTRUCTION_TEXT_COLOR = 0xFFDDDDDD;
+
+        private static final Component INSTRUCTION_TEXT = Component
+            .literal("L-Click: Apply Matches (\u00b10.1 undercut) | Ctrl: Copy Price")
+            .withStyle(ChatFormatting.GOLD);
+
         private final ListWidget list;
-        private final Button modeToggleButton;
 
-        private ClickMode currentMode;
-        private final Consumer<ClickMode> onModeChanged;
-
-        public OrderBookPriceWidget(
-            int defaultX,
-            int defaultY,
-            ClickMode initialMode,
-            Consumer<ClickMode> onModeChanged,
-            PriceClickHandler onClickHandler
-        ) {
+        public OrderBookPriceWidget(int defaultX, int defaultY, PriceClickHandler onClickHandler) {
             super(defaultX, defaultY, DEFAULT_WIDTH, DEFAULT_HEIGHT);
-            this.currentMode = initialMode;
-            this.onModeChanged = onModeChanged;
-
-            this.modeToggleButton = Button.builder(
-                this.getModeButtonText(initialMode),
-                btn -> this.toggleMode()
-            ).bounds(0, HEADER_HEIGHT + LABEL_HEIGHT, DEFAULT_WIDTH, BUTTON_HEIGHT).build();
 
             this.list = new ListWidget(0, LIST_Y_OFFSET, DEFAULT_WIDTH, DEFAULT_HEIGHT - LIST_Y_OFFSET, "Order Book");
             this.list.setStatic().setDraggable(false);
             this.list.setItemHeight(ITEM_HEIGHT);
             this.list.onItemClick((self, renderable, index) -> {
                 if (renderable instanceof OrderBookEntry entry) {
-                    boolean copyOnly = Minecraft.getInstance().hasShiftDown() || Minecraft.getInstance().hasControlDown();
+                    boolean copyOnly = Minecraft.getInstance().hasControlDown();
                     onClickHandler.onClick(entry.getPricePerUnit(), copyOnly);
                 }
             });
         }
 
-        public void updateList(List<Renderable> items, ClickMode mode) {
+        public void updateList(List<Renderable> items) {
             this.list.setItems(items);
-            this.setMode(mode);
-        }
-
-        public ClickMode getMode() {
-            return this.currentMode;
-        }
-
-        public void setMode(ClickMode mode) {
-            this.currentMode = mode;
-            this.modeToggleButton.setMessage(this.getModeButtonText(mode));
-        }
-
-        private void toggleMode() {
-            this.currentMode = this.currentMode == ClickMode.Matched ? ClickMode.Undercut : ClickMode.Matched;
-            this.modeToggleButton.setMessage(this.getModeButtonText(this.currentMode));
-            this.onModeChanged.accept(this.currentMode);
-        }
-
-        private Component getModeButtonText(ClickMode mode) {
-            return Component.literal(mode == ClickMode.Matched ? "[Switch to Undercut]" : "[Switch to Copy]")
-                .withStyle(mode == ClickMode.Matched ? ChatFormatting.GOLD : ChatFormatting.AQUA);
-        }
-
-        private Component getModeInstruction() {
-            return switch (this.currentMode) {
-                case Matched -> Component.literal("L-Click: Copy Price").withStyle(ChatFormatting.AQUA);
-                case Undercut -> Component.literal("L-Click: Undercut Price").withStyle(ChatFormatting.GOLD);
-            };
         }
 
         @Override
         protected void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta, RenderContext ctx) {
-            graphics.fill(this.getX(), this.getY(), this.getX() + this.width, this.getY() + HEADER_HEIGHT, 0xC0000000);
-            graphics.drawCenteredString(Minecraft.getInstance().font, "Order Book", this.getX() + this.width / 2, this.getY() + 4, 0xFFFFFFFF);
+            this.renderHeader(graphics);
+            this.renderInstruction(graphics);
+            this.renderList(graphics, mouseX, mouseY, delta);
+        }
 
-            graphics.fill(this.getX(), this.getY() + HEADER_HEIGHT, this.getX() + this.width, this.getY() + LIST_Y_OFFSET, 0x80000000);
-            graphics.drawCenteredString(Minecraft.getInstance().font, this.getModeInstruction(), this.getX() + this.width / 2, this.getY() + HEADER_HEIGHT + 3, 0xFFDDDDDD);
+        private void renderHeader(GuiGraphics graphics) {
+            graphics.fill(this.getX(), this.getY(), this.getX() + this.width, this.getY() + HEADER_HEIGHT, HEADER_BACKGROUND_COLOR);
+            graphics.drawCenteredString(Minecraft.getInstance().font, "Order Book", this.getX() + this.width / 2, this.getY() + 4, TITLE_COLOR);
+        }
 
-            this.modeToggleButton.setX(this.getX());
-            this.modeToggleButton.setY(this.getY() + HEADER_HEIGHT + LABEL_HEIGHT);
-            this.modeToggleButton.render(graphics, mouseX, mouseY, delta);
+        private void renderInstruction(GuiGraphics graphics) {
+            int x = this.getX();
+            int y = this.getY() + HEADER_HEIGHT;
+            int width = this.width;
+            int height = LIST_Y_OFFSET - HEADER_HEIGHT;
 
+            graphics.fill(
+                x,
+                y,
+                x + width,
+                y + height,
+                INSTRUCTION_BACKGROUND_COLOR
+            );
+            graphics.drawCenteredString(
+                Minecraft.getInstance().font,
+                INSTRUCTION_TEXT,
+                x + width / 2,
+                y + 3,
+                INSTRUCTION_TEXT_COLOR
+            );
+        }
+
+        private void renderList(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
             this.list.setX(this.getX());
             this.list.setY(this.getY() + LIST_Y_OFFSET);
             this.list.render(graphics, mouseX, mouseY, delta);
@@ -480,9 +430,6 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         @Override
         public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
-            if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseClicked(event, doubleClick)) {
-                return true;
-            }
             if (this.list.isMouseOver(event.x(), event.y()) && this.list.mouseClicked(event, doubleClick)) {
                 return true;
             }
@@ -494,9 +441,6 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         public boolean mouseReleased(MouseButtonEvent event) {
             if (this.isDragging()) {
                 return super.mouseReleased(event);
-            }
-            if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseReleased(event)) {
-                return true;
             }
             if (this.list.mouseReleased(event)) {
                 return true;
@@ -517,7 +461,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         @Override
         public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-            if (this.list.isMouseOver(mouseX, mouseY) && this.list.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)){
+            if (this.list.isMouseOver(mouseX, mouseY) && this.list.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) {
                 return true;
             }
             return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -26,7 +26,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.inventory.ClickType;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product.Summary;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,12 +36,8 @@ import java.util.Optional;
 @Slf4j
 public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookPriceConfig> {
 
-    private static final int PRICE_SETUP_SIGN_TRIGGER_SLOT = 16;
-
     private OrderBookPriceWidget widget;
 
-    private double pendingPrice = -1;
-    private boolean pendingSubmit = false;
     @Nullable private OrderType currentOrderType;
 
     @Override
@@ -56,7 +51,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             this.refreshCurrentOrderType(curr, prev);
 
             if (!this.isEnterPriceScreen(curr, prev)) {
-                if (this.pendingSubmit || this.pendingPrice >= 0 || this.currentOrderType != null) {
+                if (this.currentOrderType != null) {
                     log.debug(
                         "Clearing stale overlay state: prev={}, curr={}",
                         prev.getMenuType(),
@@ -64,33 +59,8 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                     );
                 }
 
-                this.pendingPrice = -1;
-                this.pendingSubmit = false;
                 this.currentOrderType = null;
             }
-        });
-
-        ScreenInfoHelper.registerOnSwitch(info -> {
-            if (!this.configState.enabled) {
-                return;
-            }
-
-            var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
-            if (productNameInfo == null || 
-                !(info.getScreen() instanceof SignEditScreen signEditScreen)
-            ) {
-                return;
-            }
-
-            if (!this.pendingSubmit || this.pendingPrice < 0) {
-                return;
-            }
-
-            String priceStr = Utils.formatDecimal(this.pendingPrice, 1, false);
-            GameUtils.submitSignValue(signEditScreen, priceStr);
-
-            this.pendingPrice = -1;
-            this.pendingSubmit = false;
         });
 
         BtrBz.bazaarData().addListener(products -> {
@@ -228,6 +198,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
 
         this.currentOrderType = orderType;
+
         if (copyOnly) {
             String formattedPrice = Utils.formatDecimal(rawPrice, 1, false);
             GameUtils.copyToClipboard(formattedPrice);
@@ -241,29 +212,11 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         double priceToUse = this.applyUndercut(rawPrice, orderType);
 
-        var client = Minecraft.getInstance();
-        var player = client.player;
-        var interactionManager = client.gameMode;
-        if (player == null || interactionManager == null) {
-            return;
-        }
-
-        this.pendingSubmit = true;
-        this.pendingPrice = priceToUse;
-
         log.debug("Price click processed: rawPrice={}, finalPrice={}", rawPrice, priceToUse);
 
         if (currInfo.getScreen() instanceof SignEditScreen signEditScreen) {
             GameUtils.submitSignValue(signEditScreen, Utils.formatDecimal(priceToUse, 1, false));
-
-            this.pendingPrice = -1;
-            this.pendingSubmit = false;
-            return;
         }
-
-        interactionManager.handleInventoryMouseClick(
-            currInfo.getGenericContainerScreen().get().getMenu().containerId, PRICE_SETUP_SIGN_TRIGGER_SLOT, 1, ClickType.PICKUP, player
-        );
     }
 
     private double applyUndercut(double rawPrice, OrderType orderType) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -4,9 +4,9 @@ import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.ProductInfoProvider;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen.OptionGrouping;
-import com.github.lutzluca.btrbz.core.order_book.OrderBookScreen.OrderBookRenderable;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
 import com.github.lutzluca.btrbz.utils.GameUtils;
+import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
@@ -28,6 +28,7 @@ import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.ClickType;
+import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product.Summary;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -42,7 +43,6 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
     private OrderBookPriceWidget widget;
 
-    // Transaction state
     private double pendingPrice = -1;
     private boolean pendingSubmit = false;
     @Nullable private OrderType currentOrderType;
@@ -50,18 +50,14 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
     @Override
     public void onLoad() {
         ScreenInfoHelper.registerOnSwitch(curr -> {
-            if (!this.configState.enabled || this.configState.displayMode == DisplayMode.Off) {
+            if (!this.configState.enabled) {
                 return;
             }
 
             var prev = ScreenInfoHelper.get().getPrevInfo();
             this.refreshCurrentOrderType(curr, prev);
 
-            if (this.isContainerPriceScreen(curr)) {
-                this.rebuildLists();
-            }
-
-            if (!this.isPriceScreen(curr)) {
+            if (!this.isEnterPriceScreen(curr, prev)) {
                 if (this.pendingSubmit || this.pendingPrice >= 0 || this.currentOrderType != null) {
                     log.debug(
                         "Clearing stale overlay state: prev={}, curr={}",
@@ -81,11 +77,10 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 return;
             }
 
-            if (this.getCurrentProductId() == null) {
-                return;
-            }
-
-            if (!(info.getScreen() instanceof SignEditScreen signEditScreen)) {
+            var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+            if (productNameInfo == null || 
+                !(info.getScreen() instanceof SignEditScreen signEditScreen)
+            ) {
                 return;
             }
 
@@ -93,47 +88,38 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 return;
             }
 
-            // Submit price directly to the sign
             String priceStr = Utils.formatDecimal(this.pendingPrice, 1, false);
             GameUtils.submitSignValue(signEditScreen, priceStr);
 
             this.pendingPrice = -1;
             this.pendingSubmit = false;
         });
-        
-        // Also listen for data updates so order lists refresh
+
         BtrBz.bazaarData().addListener(products -> {
-            if (this.isDisplayed() && this.getCurrentProductId() != null) {
-                this.rebuildLists();
+            var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+            if (this.isDisplayed() && productNameInfo != null) {
+                this.rebuildList();
             }
         });
     }
 
-    private @Nullable String getCurrentProductId() {
-        var info = ProductInfoProvider.get().getOpenedProductNameInfo();
-        return info != null ? info.productId() : null;
-    }
+    private boolean isEnterPriceScreen(ScreenInfo curr, ScreenInfo prev) {
+        var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+        if (!(curr.getScreen() instanceof SignEditScreen) || productNameInfo == null) {
+            return false;
+        }
 
-    private boolean isContainerPriceScreen(ScreenInfo info) {
-        return info.inMenu(BazaarMenuType.BuyOrderSetupPrice, BazaarMenuType.SellOfferSetup);
-    }
-
-    private boolean isSignPriceScreen(ScreenInfo info) {
-        return info.getScreen() instanceof SignEditScreen && this.getCurrentProductId() != null;
-    }
-
-    private boolean isPriceScreen(ScreenInfo info) {
-        return this.isContainerPriceScreen(info) || this.isSignPriceScreen(info);
+        return prev.inMenu(BazaarMenuType.BuyOrderSetupPrice, BazaarMenuType.SellOfferSetup);
     }
 
     private Optional<OrderType> resolveCurrentOrderType(ScreenInfo curr, ScreenInfo prev) {
-        if (curr.inMenu(BazaarMenuType.BuyOrderSetupPrice) ||
-            (curr.getScreen() instanceof SignEditScreen && prev.inMenu(BazaarMenuType.BuyOrderSetupPrice))) {
+        boolean isSign = curr.getScreen() instanceof SignEditScreen;
+
+        if (isSign && prev.inMenu(BazaarMenuType.BuyOrderSetupPrice)) {
             return Optional.of(OrderType.Buy);
         }
 
-        if (curr.inMenu(BazaarMenuType.SellOfferSetup) ||
-            (curr.getScreen() instanceof SignEditScreen && prev.inMenu(BazaarMenuType.SellOfferSetup))) {
+        if (isSign && prev.inMenu(BazaarMenuType.SellOfferSetup)) {
             return Optional.of(OrderType.Sell);
         }
 
@@ -144,117 +130,98 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         this.resolveCurrentOrderType(curr, prev).ifPresent(orderType -> this.currentOrderType = orderType);
     }
 
-    public enum PriceScreen {
-        Container,
-        Sign
-    }
-
-    private Optional<PriceScreen> getPriceScreen(ScreenInfo info) {
-        if (this.isContainerPriceScreen(info)) {
-            return Optional.of(PriceScreen.Container);
-        }
-
-        if (this.isSignPriceScreen(info)) {
-            return Optional.of(PriceScreen.Sign);
-        }
-
-        return Optional.empty();
-    }
-
     @Override
     public boolean shouldDisplay(ScreenInfo info) {
-        if (!this.configState.enabled || this.configState.displayMode == DisplayMode.Off) {
+        if (!this.configState.enabled) {
             return false;
         }
 
-        return this.getCurrentProductId() != null && this.getPriceScreen(info).isPresent();
+        var prev = ScreenInfoHelper.get().getPrevInfo();
+        var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+        return productNameInfo != null && this.isEnterPriceScreen(info, prev);
     }
 
-    public void rebuildLists() {
+    public void rebuildList() {
         if (this.widget == null) {
             return;
         }
 
-        var productId = this.getCurrentProductId();
-        if (productId == null) {
+        var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+        if (productNameInfo == null) {
             return;
         }
 
-        if (this.configState.displayMode == DisplayMode.Relevant && this.currentOrderType == null) {
+        if (this.currentOrderType == null) {
+            log.debug("Current order type is null, clearing list for product {}", productNameInfo.productName());
+            this.widget.updateList(List.of(), this.configState.clickMode);
             return;
         }
 
-        var orders = BtrBz.bazaarData().getOrderLists(productId);
+        var orders = BtrBz.bazaarData().getOrderLists(productNameInfo.productId());
+        var productName = productNameInfo.productName();
 
-        List<Renderable> buyWidgets = new ArrayList<>();
-        for (var summary : orders.buyOrders()) {
-            buyWidgets.add(new OrderBookRenderable(summary, OrderType.Buy));
-        }
-
-        List<Renderable> sellWidgets = new ArrayList<>();
-        for (var summary : orders.sellOffers()) {
-            sellWidgets.add(new OrderBookRenderable(summary, OrderType.Sell));
-        }
-
-        boolean showBuy = switch (this.configState.displayMode) {
-            case Relevant -> this.currentOrderType == OrderType.Buy;
-            case Both -> true;
-            case Off -> false;
+        var summaries = switch (this.currentOrderType) {
+            case Buy -> orders.buyOrders();
+            case Sell -> orders.sellOffers();
         };
 
-        boolean showSell = switch (this.configState.displayMode) {
-            case Relevant -> this.currentOrderType == OrderType.Sell;
-            case Both -> true;
-            case Off -> false;
-        };
+        List<Renderable> entries = new ArrayList<>();
+        for (var summary : summaries) {
+            entries.add(new OrderBookEntry(productName, summary, this.currentOrderType));
+        }
 
-        this.widget.updateLists(showBuy, buyWidgets, showSell, sellWidgets, this.configState.clickMode);
+        this.widget.updateList(entries, this.configState.clickMode);
     }
 
     @Override
     public List<DraggableWidget> createWidgets(ScreenInfo info) {
-        var screen = this.getPriceScreen(info);
-        if (screen.isEmpty()) {
+        var prev = ScreenInfoHelper.get().getPrevInfo();
+        if (!this.isEnterPriceScreen(info, prev)) {
+            return List.of();
+        }
+        this.resolveCurrentOrderType(info, prev).ifPresent(orderType -> this.currentOrderType = orderType);
+
+        if (this.currentOrderType == null) {
             return List.of();
         }
 
-        var bounds = info
-            .getHandledScreenBounds()
-            .or(() -> ScreenInfoHelper.get().getPrevInfo().getHandledScreenBounds());
-
-        if (bounds.isEmpty()) {
-            return List.of();
-        }
-
-        int x = bounds.get().x();
-        int y = 0;
-        int width = bounds.get().width();
-        int height = Math.max(bounds.get().y(), 0);
-
+        var position = this.getPosition();
         if (this.widget == null) {
             this.widget = new OrderBookPriceWidget(
-                x,
-                y,
-                width,
-                height,
+                position.map(Position::x).orElse(20),
+                position.map(Position::y).orElse(20),
                 this.configState.clickMode,
                 mode -> this.updateConfig(cfg -> cfg.clickMode = mode),
                 this::handlePriceClick
             );
-            this.widget.setDraggable(false);
+
+            this.widget.onDragEnd((self, pos) -> this.savePosition(pos));
         } else {
-            this.widget.setX(x);
-            this.widget.setY(y);
-            this.widget.setOverlayBounds(width, height);
             this.widget.setMode(this.configState.clickMode);
         }
 
-        this.rebuildLists();
+        this.widget.setDraggable(true);
+
+        this.rebuildList();
         return List.of(this.widget);
     }
 
+    private Optional<Position> getPosition() {
+        return Utils
+            .zipNullables(this.configState.signX, this.configState.signY)
+            .map(Position::from);
+    }
+
+    private void savePosition(Position pos) {
+        this.updateConfig(cfg -> {
+            cfg.signX = pos.x();
+            cfg.signY = pos.y();
+        });
+    }
+
     private void handlePriceClick(double rawPrice, boolean copyOnly) {
-        if (this.getCurrentProductId() == null) {
+        var productNameInfo = ProductInfoProvider.get().getOpenedProductNameInfo();
+        if (productNameInfo == null) {
             return;
         }
 
@@ -266,7 +233,6 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
 
         this.currentOrderType = orderType;
-
         ClickMode mode = this.widget.getMode();
         double priceToUse = rawPrice;
 
@@ -276,7 +242,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 case Sell -> priceToUse = Math.max(rawPrice - 0.1, 0.1);
             }
         }
-        
+
         if (copyOnly) {
             GameUtils.copyToClipboard(Utils.formatDecimal(priceToUse, 1, false));
             return;
@@ -307,25 +273,8 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         );
     }
 
-    public enum DisplayMode {
-        Relevant,
-        Both,
-        Off;
-
-        public static EnumControllerBuilder<DisplayMode> controller(Option<DisplayMode> option) {
-            return EnumControllerBuilder
-                .create(option)
-                .enumClass(DisplayMode.class)
-                .formatValue(mode -> switch (mode) {
-                    case Relevant -> Component.literal("Relevant Only");
-                    case Both -> Component.literal("Both");
-                    case Off -> Component.literal("Off");
-                });
-        }
-    }
-
     public enum ClickMode {
-        Copy,
+        Matched,
         Undercut;
 
         public static EnumControllerBuilder<ClickMode> controller(Option<ClickMode> option) {
@@ -333,15 +282,16 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 .create(option)
                 .enumClass(ClickMode.class)
                 .formatValue(mode -> switch (mode) {
-                    case Copy -> Component.literal("Copy Price");
+                    case Matched -> Component.literal("Copy Price");
                     case Undercut -> Component.literal("Undercut (±0.1)");
                 });
         }
     }
 
     public static class OrderBookPriceConfig {
+        public Integer signX;
+        public Integer signY;
         public boolean enabled = true;
-        public DisplayMode displayMode = DisplayMode.Relevant;
         public ClickMode clickMode = ClickMode.Undercut;
 
         public Option.Builder<Boolean> createEnableOption() {
@@ -349,23 +299,9 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 .<Boolean>createBuilder()
                 .name(Component.nullToEmpty("Order Book Price Overlay: Master Switch"))
                 .description(OptionDescription.of(Component.literal(
-                    "Master switch to enable or disable the Order Book overlay on price entry screens.")))
+                    "Enable or disable the Order Book overlay on price sign screens.")))
                 .binding(true, () -> this.enabled, val -> this.enabled = val)
                 .controller(ConfigScreen::createBooleanController);
-        }
-
-        public Option.Builder<DisplayMode> createDisplayModeOption() {
-            return Option
-                .<DisplayMode>createBuilder()
-                .name(Component.nullToEmpty("Display Mode"))
-                .description(OptionDescription.of(Component.literal(
-                    "Which order lists to show on the overlay.")))
-                .binding(
-                    DisplayMode.Relevant,
-                    () -> this.displayMode != null ? this.displayMode : DisplayMode.Relevant,
-                    val -> this.displayMode = val
-                )
-                .controller(DisplayMode::controller);
         }
 
         public Option.Builder<ClickMode> createClickModeOption() {
@@ -384,16 +320,13 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
         public OptionGroup createGroup() {
             var rootGroup = new OptionGrouping(this.createEnableOption())
-                .addOptions(
-                    this.createDisplayModeOption(),
-                    this.createClickModeOption()
-                );
+                .addOptions(this.createClickModeOption());
 
             return OptionGroup
                 .createBuilder()
                 .name(Component.nullToEmpty("Order Book Price Overlay"))
                 .description(OptionDescription.of(Component.literal(
-                    "Displays order book data over the price entry sign/menu.")))
+                    "Displays order book data next to the price entry sign.")))
                 .options(rootGroup.build())
                 .collapsed(false)
                 .build();
@@ -405,84 +338,102 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         void onClick(double rawPrice, boolean copyOnly);
     }
 
+    private static class OrderBookEntry implements Renderable {
+        private final Summary summary;
+        private final OrderType type;
+        private final Component priceText;
+        private final Component statsText;
+
+        public OrderBookEntry(String productName, Summary summary, OrderType type) {
+            this.summary = summary;
+            this.type = type;
+            this.priceText = Component.literal(Utils.formatDecimal(summary.getPricePerUnit(), 1, true));
+
+            int orders = (int) summary.getOrders();
+            String volumeStr = Utils.formatDecimal(summary.getAmount(), 0, true);
+            this.statsText = Component.literal(volumeStr + " | " + orders);
+        }
+
+        @Override
+        public void render(
+            GuiGraphics graphics,
+            int x, int y,
+            int width, int height,
+            int mouseX, int mouseY, float delta,
+            boolean hovered
+        ) {
+            var font = Minecraft.getInstance().font;
+
+            if (hovered) {
+                int color = this.type == OrderType.Buy ? 0x6022AA22 : 0x60AA2222;
+                graphics.fill(x, y, x + width, y + height, color);
+            }
+
+            int priceColor = this.type == OrderType.Buy ? 0xFF55FF55 : 0xFFFF5555;
+            int textY = y + (height - font.lineHeight) / 2;
+
+            graphics.drawString(font, this.priceText, x + 5, textY, priceColor);
+
+            int statsWidth = font.width(this.statsText);
+            graphics.drawString(font, this.statsText, x + width - statsWidth - 5, textY, 0xFFCCCCCC);
+        }
+
+        public double getPricePerUnit() {
+            return this.summary.getPricePerUnit();
+        }
+    }
+
+    // it should be explained why we have this here with all the forwarding of the 
+    // callbacks
     private static class OrderBookPriceWidget extends DraggableWidget {
         private static final int HEADER_HEIGHT = 16;
         private static final int LABEL_HEIGHT = 14;
         private static final int BUTTON_HEIGHT = 16;
         private static final int CONTROLS_HEIGHT = LABEL_HEIGHT + BUTTON_HEIGHT;
         private static final int LIST_Y_OFFSET = HEADER_HEIGHT + CONTROLS_HEIGHT;
-        private static final int LIST_GAP = 5;
-        private static final int MIN_LIST_WIDTH = 80;
-        private static final int MIN_LIST_HEIGHT = 30;
+        private static final int ITEM_HEIGHT = 16;
 
-        private final ListWidget buyList;
-        private final ListWidget sellList;
+        private static final int DEFAULT_WIDTH = 280;
+        private static final int DEFAULT_HEIGHT = 220;
+
+        private final ListWidget list;
         private final Button modeToggleButton;
-        
+
         private ClickMode currentMode;
         private final Consumer<ClickMode> onModeChanged;
-        
-        private boolean showBuy;
-        private boolean showSell;
-
-        private int listWidth;
-        private int listHeight;
 
         public OrderBookPriceWidget(
             int defaultX,
             int defaultY,
-            int width,
-            int height,
             ClickMode initialMode,
             Consumer<ClickMode> onModeChanged,
             PriceClickHandler onClickHandler
         ) {
-            super(defaultX, defaultY, width, height);
+            super(defaultX, defaultY, DEFAULT_WIDTH, DEFAULT_HEIGHT);
             this.currentMode = initialMode;
             this.onModeChanged = onModeChanged;
 
-            this.listWidth = Math.max((width - LIST_GAP) / 2, MIN_LIST_WIDTH);
-            this.listHeight = Math.max(height - LIST_Y_OFFSET, MIN_LIST_HEIGHT);
-
-            // Mode toggle button spans the width at the top (under drag handle area + label)
             this.modeToggleButton = Button.builder(
                 this.getModeButtonText(initialMode),
                 btn -> this.toggleMode()
-            ).bounds(0, HEADER_HEIGHT + LABEL_HEIGHT, width, BUTTON_HEIGHT).build();
+            ).bounds(0, HEADER_HEIGHT + LABEL_HEIGHT, DEFAULT_WIDTH, BUTTON_HEIGHT).build();
 
-            this.buyList = new ListWidget(0, LIST_Y_OFFSET, this.listWidth, this.listHeight, "Buy Orders");
-            this.buyList.setStatic().setDraggable(false);
-            this.buyList.setItemHeight(14);
-            this.buyList.onItemClick((self, renderable, index) -> {
-                if (renderable instanceof OrderBookRenderable br) {
+            this.list = new ListWidget(0, LIST_Y_OFFSET, DEFAULT_WIDTH, DEFAULT_HEIGHT - LIST_Y_OFFSET, "Order Book");
+            this.list.setStatic().setDraggable(false);
+            this.list.setItemHeight(ITEM_HEIGHT);
+            this.list.onItemClick((self, renderable, index) -> {
+                if (renderable instanceof OrderBookEntry entry) {
                     boolean copyOnly = Minecraft.getInstance().hasShiftDown() || Minecraft.getInstance().hasControlDown();
-                    onClickHandler.onClick(br.getPricePerUnit(), copyOnly);
+                    onClickHandler.onClick(entry.getPricePerUnit(), copyOnly);
                 }
             });
-
-            this.sellList = new ListWidget(0, LIST_Y_OFFSET, this.listWidth, this.listHeight, "Sell Offers");
-            this.sellList.setStatic().setDraggable(false);
-            this.sellList.setItemHeight(14);
-            this.sellList.onItemClick((self, renderable, index) -> {
-                if (renderable instanceof OrderBookRenderable br) {
-                    boolean copyOnly = Minecraft.getInstance().hasShiftDown() || Minecraft.getInstance().hasControlDown();
-                    onClickHandler.onClick(br.getPricePerUnit(), copyOnly);
-                }
-            });
-
-            this.setDraggable(false);
-            this.setOverlayBounds(width, height);
         }
 
-        public void setOverlayBounds(int width, int height) {
-            this.width = Math.max(width, MIN_LIST_WIDTH);
-            this.height = Math.max(height, LIST_Y_OFFSET + MIN_LIST_HEIGHT);
-
-            this.modeToggleButton.setWidth(this.width);
-            this.updateChildLayout();
-            this.updateChildPositions();
+        public void updateList(List<Renderable> items, ClickMode mode) {
+            this.list.setItems(items);
+            this.setMode(mode);
         }
-        
+
         public ClickMode getMode() {
             return this.currentMode;
         }
@@ -493,99 +444,38 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
 
         private void toggleMode() {
-            this.currentMode = this.currentMode == ClickMode.Copy ? ClickMode.Undercut : ClickMode.Copy;
+            this.currentMode = this.currentMode == ClickMode.Matched ? ClickMode.Undercut : ClickMode.Matched;
             this.modeToggleButton.setMessage(this.getModeButtonText(this.currentMode));
             this.onModeChanged.accept(this.currentMode);
         }
 
         private Component getModeButtonText(ClickMode mode) {
-            return Component.literal(mode == ClickMode.Copy ? "[Switch to Undercut]" : "[Switch to Copy]")
-                .withStyle(mode == ClickMode.Copy ? ChatFormatting.GOLD : ChatFormatting.AQUA);
+            return Component.literal(mode == ClickMode.Matched ? "[Switch to Undercut]" : "[Switch to Copy]")
+                .withStyle(mode == ClickMode.Matched ? ChatFormatting.GOLD : ChatFormatting.AQUA);
         }
 
         private Component getModeInstruction() {
-            if (this.currentMode == ClickMode.Copy) {
-                return Component.literal("L-Click: Copy Price").withStyle(ChatFormatting.AQUA);
-            } else {
-                return Component.literal("L-Click: Undercut Price").withStyle(ChatFormatting.GOLD);
-            }
-        }
-
-        public void updateLists(boolean showBuy, List<Renderable> buyItems, boolean showSell, List<Renderable> sellItems, ClickMode mode) {
-            this.showBuy = showBuy;
-            this.showSell = showSell;
-            this.buyList.setItems(buyItems);
-            this.sellList.setItems(sellItems);
-            this.setMode(mode);
-
-            this.updateChildLayout();
-            this.updateChildPositions();
-        }
-
-        @Override
-        public void setX(int x) {
-            super.setX(x);
-            this.updateChildPositions();
-        }
-
-        @Override
-        public void setY(int y) {
-            super.setY(y);
-            this.updateChildPositions();
-        }
-
-        private void updateChildLayout() {
-            int visibleColumns = (this.showBuy ? 1 : 0) + (this.showSell ? 1 : 0);
-            if (visibleColumns <= 0) {
-                this.listWidth = Math.max(this.width, MIN_LIST_WIDTH);
-            } else {
-                int gap = visibleColumns > 1 ? LIST_GAP : 0;
-                this.listWidth = Math.max((this.width - gap) / visibleColumns, MIN_LIST_WIDTH);
-            }
-
-            this.listHeight = Math.max(this.height - LIST_Y_OFFSET, MIN_LIST_HEIGHT);
-
-            this.buyList.setWidth(this.listWidth);
-            this.buyList.setHeight(this.listHeight);
-            this.sellList.setWidth(this.listWidth);
-            this.sellList.setHeight(this.listHeight);
-        }
-
-        private void updateChildPositions() {
-            this.modeToggleButton.setX(this.getX());
-            this.modeToggleButton.setY(this.getY() + HEADER_HEIGHT + LABEL_HEIGHT);
-
-            int curX = this.getX();
-            if (this.showBuy) {
-                this.buyList.setX(curX);
-                if (this.showSell) {
-                    curX += this.listWidth + LIST_GAP;
-                }
-            }
-            if (this.showSell) {
-                this.sellList.setX(curX);
-            }
-
-            this.buyList.setY(this.getY() + LIST_Y_OFFSET);
-            this.sellList.setY(this.getY() + LIST_Y_OFFSET);
+            return switch (this.currentMode) {
+                case Matched -> Component.literal("L-Click: Copy Price").withStyle(ChatFormatting.AQUA);
+                case Undercut -> Component.literal("L-Click: Undercut Price").withStyle(ChatFormatting.GOLD);
+            };
         }
 
         @Override
         protected void renderContent(GuiGraphics graphics, int mouseX, int mouseY, float delta, RenderContext ctx) {
-            // Main Widget Header
             graphics.fill(this.getX(), this.getY(), this.getX() + this.width, this.getY() + HEADER_HEIGHT, 0xC0000000);
             graphics.drawCenteredString(Minecraft.getInstance().font, "Order Book", this.getX() + this.width / 2, this.getY() + 4, 0xFFFFFFFF);
 
-            // Controls area background
             graphics.fill(this.getX(), this.getY() + HEADER_HEIGHT, this.getX() + this.width, this.getY() + LIST_Y_OFFSET, 0x80000000);
-            
-            // Instructions Label
             graphics.drawCenteredString(Minecraft.getInstance().font, this.getModeInstruction(), this.getX() + this.width / 2, this.getY() + HEADER_HEIGHT + 3, 0xFFDDDDDD);
 
+            this.modeToggleButton.setX(this.getX());
+            this.modeToggleButton.setY(this.getY() + HEADER_HEIGHT + LABEL_HEIGHT);
             this.modeToggleButton.render(graphics, mouseX, mouseY, delta);
 
-            if (this.showBuy) this.buyList.render(graphics, mouseX, mouseY, delta);
-            if (this.showSell) this.sellList.render(graphics, mouseX, mouseY, delta);
+            this.list.setX(this.getX());
+            this.list.setY(this.getY() + LIST_Y_OFFSET);
+            this.list.render(graphics, mouseX, mouseY, delta);
         }
 
         @Override
@@ -593,8 +483,10 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseClicked(event, doubleClick)) {
                 return true;
             }
-            if (this.showBuy && this.buyList.isMouseOver(event.x(), event.y()) && this.buyList.mouseClicked(event, doubleClick)) return true;
-            if (this.showSell && this.sellList.isMouseOver(event.x(), event.y()) && this.sellList.mouseClicked(event, doubleClick)) return true;
+            if (this.list.isMouseOver(event.x(), event.y()) && this.list.mouseClicked(event, doubleClick)) {
+                return true;
+            }
+
             return super.mouseClicked(event, doubleClick);
         }
 
@@ -606,8 +498,9 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             if (this.modeToggleButton.isMouseOver(event.x(), event.y()) && this.modeToggleButton.mouseReleased(event)) {
                 return true;
             }
-            if (this.showBuy && this.buyList.mouseReleased(event)) return true;
-            if (this.showSell && this.sellList.mouseReleased(event)) return true;
+            if (this.list.mouseReleased(event)) {
+                return true;
+            }
             return super.mouseReleased(event);
         }
 
@@ -616,15 +509,17 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             if (this.isDragging()) {
                 return super.mouseDragged(event, deltaX, deltaY);
             }
-            if (this.showBuy && this.buyList.isMouseOver(event.x(), event.y()) && this.buyList.mouseDragged(event, deltaX, deltaY)) return true;
-            if (this.showSell && this.sellList.isMouseOver(event.x(), event.y()) && this.sellList.mouseDragged(event, deltaX, deltaY)) return true;
+            if (this.list.isMouseOver(event.x(), event.y()) && this.list.mouseDragged(event, deltaX, deltaY)) {
+                return true;
+            }
             return super.mouseDragged(event, deltaX, deltaY);
         }
 
         @Override
         public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-            if (this.showBuy && this.buyList.isMouseOver(mouseX, mouseY) && this.buyList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) return true;
-            if (this.showSell && this.sellList.isMouseOver(mouseX, mouseY) && this.sellList.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)) return true;
+            if (this.list.isMouseOver(mouseX, mouseY) && this.list.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount)){
+                return true;
+            }
             return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
         }
     }

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -163,8 +163,10 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         };
 
         List<Renderable> entries = new ArrayList<>();
+        double accumulatedVolume = 0;
         for (var summary : summaries) {
-            entries.add(new OrderBookEntry(summary, this.currentOrderType));
+            accumulatedVolume += summary.getAmount();
+            entries.add(new OrderBookEntry(summary, this.currentOrderType, accumulatedVolume));
         }
 
         this.widget.updateList(entries);
@@ -226,10 +228,8 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         }
 
         this.currentOrderType = orderType;
-        double priceToUse = this.applyUndercut(rawPrice, orderType);
-
         if (copyOnly) {
-            String formattedPrice = Utils.formatDecimal(priceToUse, 1, false);
+            String formattedPrice = Utils.formatDecimal(rawPrice, 1, false);
             GameUtils.copyToClipboard(formattedPrice);
             Notifier.notifyPlayer(Notifier
                 .prefix()
@@ -238,6 +238,8 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 .append(Component.literal(" to clipboard").withStyle(ChatFormatting.GRAY)));
             return;
         }
+
+        double priceToUse = this.applyUndercut(rawPrice, orderType);
 
         var client = Minecraft.getInstance();
         var player = client.player;
@@ -310,15 +312,24 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         private final OrderType type;
         private final Component priceText;
         private final Component statsText;
+        private final List<Component> tooltip;
 
-        public OrderBookEntry(Summary summary, OrderType type) {
+        public OrderBookEntry(Summary summary, OrderType type, double accumulatedVolume) {
             this.summary = summary;
             this.type = type;
             this.priceText = Component.literal(Utils.formatDecimal(summary.getPricePerUnit(), 1, true));
 
             int orders = (int) summary.getOrders();
             String volumeStr = Utils.formatDecimal(summary.getAmount(), 0, true);
-            this.statsText = Component.literal(volumeStr + " | " + orders);
+            this.statsText = Component.literal("Vol: " + volumeStr + "  Ord: " + orders);
+
+            String cumulativeVolumeStr = Utils.formatDecimal(accumulatedVolume, 0, true);
+            this.tooltip = List.of(
+                Component.literal("Price: " + Utils.formatDecimal(summary.getPricePerUnit(), 1, true)).withStyle(ChatFormatting.GOLD),
+                Component.literal("Level Volume: " + volumeStr).withStyle(ChatFormatting.GRAY),
+                Component.literal("Orders: " + orders).withStyle(ChatFormatting.GRAY),
+                Component.literal("Cumulative Volume: " + cumulativeVolumeStr).withStyle(ChatFormatting.AQUA)
+            );
         }
 
         @Override
@@ -348,6 +359,11 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         public double getPricePerUnit() {
             return this.summary.getPricePerUnit();
         }
+
+        @Override
+        public List<Component> getTooltip() {
+            return this.tooltip;
+        }
     }
 
     private static class OrderBookPriceWidget extends DraggableWidget {
@@ -356,7 +372,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         private static final int LIST_Y_OFFSET = HEADER_HEIGHT + INSTRUCTION_HEIGHT;
         private static final int ITEM_HEIGHT = 16;
 
-        private static final int DEFAULT_WIDTH = 280;
+        private static final int DEFAULT_WIDTH = 230;
         private static final int DEFAULT_HEIGHT = 220;
 
         private static final int HEADER_BACKGROUND_COLOR = 0xC0000000;
@@ -365,7 +381,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
         private static final int INSTRUCTION_TEXT_COLOR = 0xFFDDDDDD;
 
         private static final Component INSTRUCTION_TEXT = Component
-            .literal("L-Click: Apply Matches (\u00b10.1 undercut) | Ctrl: Copy Price")
+            .literal("Click -> Undercut | Ctrl-Click -> Copy price")
             .withStyle(ChatFormatting.GOLD);
 
         private final ListWidget list;

--- a/src/main/java/com/github/lutzluca/btrbz/widgets/base/DraggableWidget.java
+++ b/src/main/java/com/github/lutzluca/btrbz/widgets/base/DraggableWidget.java
@@ -95,8 +95,8 @@ public abstract class DraggableWidget extends AbstractWidget {
             int newX = this.initialX + (int)(event.x() - this.dragStartX);
             int newY = this.initialY + (int)(event.y() - this.dragStartY);
 
-            this.x = this.constrainX(newX);
-            this.y = this.constrainY(newY);
+            this.setX(this.constrainX(newX));
+            this.setY(this.constrainY(newY));
             return true;
         }
 
@@ -142,8 +142,8 @@ public abstract class DraggableWidget extends AbstractWidget {
 
         if (this.isDragging) {
             this.isDragging = false;
-            this.x = this.initialX;
-            this.y = this.initialY;
+            this.setX(this.initialX);
+            this.setY(this.initialY);
         }
     }
 


### PR DESCRIPTION
Depends on #27 

## Summary

* **New Features**
  * Added relevant Order Book Price overlay for bazaar price entry screens (sign screens). The configurable widget displays current market prices and enables quick entry with clipboard copying and smart price adjustment, i.e. submitting a undercut of a specific order.

* **Changes**
  * State Persistence: Refactored ProductInfoProvider to maintain product context through the entire transaction sequence, including transitions through transient screens and the sign editor.
  * Interaction Standardization: Simplified the user interface by adopting a context-aware single list. Standardized left-click for undercut/outbid logic and Ctrl-click for clipboard copying. And displaying it in the label above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Order Book overlay for bazaar buy/sell price sign editing: shows market levels, hover tooltips, and lets clicks auto-fill undercut prices or Ctrl+click copy raw prices. Overlay is draggable, persists its position, and is toggleable via a new Order Book setting in the General configuration.
* **Bug Fixes**
  * Improved screen-transition handling so the overlay and opened product info remain stable during transient sign-edit flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->