### PR TITLE
feat: add grouped order notifications with price display options

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -148,6 +148,13 @@ public class TrackedOrderManager {
         this.sendNotifications(updates, products);        
     }
 
+    // Known limitation: transitions that only change `GroupStatus` without changing the underlying
+    // `OrderStatus` variant are not detected. Concretely, if a stranger cancels their order from
+    // your bucket, all your orders stay `OrderStatus.Matched`, no `sameVariant` change fires, so
+    // no `StatusUpdate` is produced, and `sendNotifications` never processes the group.
+    // Fixing this would require a separate group-level status diff pass (tracking previous
+    // `GroupStatus` across polls), which adds meaningful complexity for a low-value scenario.
+    // Accepted as a known limitation (for now).
     private void sendNotifications(List<StatusUpdate> statusUpdates, Map<String, Product> products) {
         var cfg = ConfigManager.get().trackedOrders;
         if(!cfg.enabled) {
@@ -246,7 +253,7 @@ public class TrackedOrderManager {
             return new GroupStatus.Undercut(undercutAmount);
         }
 
-        int bucketOrderCount = bazaarData.getBucketOrderCount(key.productName, key.type, key.pricePerUnit);
+        int bucketOrderCount = this.countOrdersAtBestPrice(key, this.bazaarData);
         if(bucketOrderCount == -1) {
             log.warn("Group ({}) has no orders at the given price per unit, skipping group notification", key);
             return null;
@@ -255,9 +262,14 @@ public class TrackedOrderManager {
         return orders.size() == bucketOrderCount ? new GroupStatus.SelfMatched() : new GroupStatus.Matched();
     }
 
-    // orders are all currently tracekd orders, while the updates are only the ones that changes, thus we can use the 
-    // orders to get the previous status of these, as they did not change their state it must be their current status
-    // for the updated orders we use the prev field
+   // Reconstruct the previous group status from two sources:
+   // - Orders that did NOT change this poll are absent from `updates`, meaning their current
+   //   status IS their previous status (nothing moved for them).
+   // - Orders that DID change this poll have an explicit `prev` field in their `StatusUpdate`,
+   //   which overrides the default.
+   // Building a full `prevStatuses` map across all orders gives us a complete picture of where
+   // the entire group stood before this poll, which we then reduce to a single `GroupStatus`
+   // using the same precedence as `getCurrentGroupStatus`: `Undercut` > `Matched` > everything else.
     private @Nullable GroupStatus getPreviousGroupStatus(GroupKey key, List<TrackedOrder> orders, List<StatusUpdate> updates) {
         Map<TrackedOrder, OrderStatus> prevStatuses = orders.stream()
             .collect(Collectors.toMap(order -> order, order -> order.status));
@@ -284,6 +296,27 @@ public class TrackedOrderManager {
         log.warn("Group ({}) has no settled matched state before, skipping group notification currently tracked orders: {} | updates: {}", 
             key, orders, updates);
         return null;
+    }
+
+    private int countOrdersAtBestPrice(GroupKey key, BazaarData bazaarData) {
+        var productId = bazaarData.nameToId(key.productName).orElse(null);
+        if (productId == null) {
+            log.warn("Group ({}) has no name -> id mapping, skipping group notification", key);
+            return -1;
+        }
+        
+        var lists = bazaarData.getOrderLists(productId);
+        
+        var relevantSummaries = switch (key.type) {
+            case Buy -> lists.buyOrders();
+            case Sell -> lists.sellOffers();
+        };
+    
+        return relevantSummaries.stream()
+            .filter(summary -> summary.getPricePerUnit() == key.pricePerUnit)
+            .findFirst()
+            .map(summary -> (int) summary.getOrders())
+            .orElse(-1);
     }
 
     public Stream<StatusUpdate> computeStatusUpdates(Map<String, Product> products) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -200,6 +200,12 @@ public class TrackedOrderManager {
         }
 
         GroupStatus curr = this.getCurrentGroupStatus(key, orders, products);
+        
+        if(curr == null) {
+            log.warn("Group ({}) has no settled status, skipping group notification", key);
+            return;
+        }
+
         boolean shouldNotify = switch (curr) {
             case GroupStatus.Undercut ignored -> cfg.notifyUndercut;
             case GroupStatus.Matched ignored -> cfg.notifyMatched;
@@ -210,12 +216,7 @@ public class TrackedOrderManager {
             return;
         }
 
-        GroupStatus prev = this.getPreviousGroupStatus(orders, updates);
-        
-        if(curr == null || prev == null) {
-            log.warn("Group ({}) has no settled status, skipping group notification: previous status: {}, current status: {}", key, prev, curr);
-            return;
-        }
+        GroupStatus prev = this.getPreviousGroupStatus(key, orders, updates);
 
         Notifier.notifyGroupOrderStatus(key, orders, curr, prev, this.bazaarData);
     }
@@ -254,11 +255,14 @@ public class TrackedOrderManager {
         return orders.size() == bucketOrderCount ? new GroupStatus.SelfMatched() : new GroupStatus.Matched();
     }
 
-    private @Nullable GroupStatus getPreviousGroupStatus(List<TrackedOrder> orders, List<StatusUpdate> updates) {
+    // orders are all currently tracekd orders, while the updates are only the ones that changes, thus we can use the 
+    // orders to get the previous status of these, as they did not change their state it must be their current status
+    // for the updated orders we use the prev field
+    private @Nullable GroupStatus getPreviousGroupStatus(GroupKey key, List<TrackedOrder> orders, List<StatusUpdate> updates) {
         Map<TrackedOrder, OrderStatus> prevStatuses = orders.stream()
             .collect(Collectors.toMap(order -> order, order -> order.status));
 
-        updates.stream().forEach(update -> prevStatuses.put(update.order(), update.prev()));
+        updates.forEach(update -> prevStatuses.put(update.order(), update.prev()));
 
         var values = prevStatuses.values();
 
@@ -277,6 +281,8 @@ public class TrackedOrderManager {
         }
 
         // Top, Unknown, or mix of both -> group had no settled matched state before
+        log.warn("Group ({}) has no settled matched state before, skipping group notification currently tracked orders: {} | updates: {}", 
+            key, orders, updates);
         return null;
     }
 
@@ -293,7 +299,7 @@ public class TrackedOrderManager {
             ));
     }
 
-       public Optional<TrackedStatus> getTrackedStatus(TrackedOrder order, Map<String, Product> products) {
+    private Optional<TrackedStatus> getTrackedStatus(TrackedOrder order, Map<String, Product> products) {
         var id = bazaarData.nameToId(order.productName);
         if (id.isEmpty()) {
             log.warn(
@@ -471,6 +477,8 @@ public class TrackedOrderManager {
 
             var rootGroup = new OptionGrouping(this.createEnabledOption())
                 .addOptions(
+                    this.createGroupOrdersOption(),
+                    this.createIncludePricePerUnitOption(),
                     this.createGotoMatchedOption(),
                     this.createGotoUndercutOption(),
                     this.createNotifyMatchedOption(),
@@ -616,6 +624,26 @@ public class TrackedOrderManager {
                 .binding(true, () -> this.soundUndercut, val -> this.soundUndercut = val)
                 .description(OptionDescription.of(Component.literal(
                     "Play a sound when an undercut notification is triggered")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<Boolean> createGroupOrdersOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Group Orders"))
+                .binding(true, () -> this.groupOrders, val -> this.groupOrders = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Group multiple orders at the same price into a single notification")))
+                .controller(ConfigScreen::createBooleanController);
+        }
+
+        private Option.Builder<Boolean> createIncludePricePerUnitOption() {
+            return Option
+                .<Boolean>createBuilder()
+                .name(Component.literal("Include Price Per Unit"))
+                .binding(false, () -> this.includePricePerUnit, val -> this.includePricePerUnit = val)
+                .description(OptionDescription.of(Component.literal(
+                    "Include the price per unit in the notification message")))
                 .controller(ConfigScreen::createBooleanController);
         }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -33,6 +33,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jetbrains.annotations.Nullable;
+
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product;
 import net.minecraft.network.chat.Component;
@@ -129,9 +131,9 @@ public class TrackedOrderManager {
         }
     }
 
-    record GroupKey(String productName, OrderType type, double pricePerUnit) {}
+    public record GroupKey(String productName, OrderType type, double pricePerUnit) {}
 
-    sealed interface GroupStatus {
+    public sealed interface GroupStatus {
         record Undercut(double amount) implements GroupStatus {}
         record Matched() implements GroupStatus {}
         record SelfMatched() implements GroupStatus {}
@@ -146,12 +148,136 @@ public class TrackedOrderManager {
         this.sendNotifications(updates, products);        
     }
 
-    private void sendNotifications(List<StatusUpdate> updates, Map<String, Product> products) {
-        updates.stream()
-            .filter(this::shouldNotify)
-            .forEach(update -> {
-                Notifier.notifyOrderStatus(update, this.bazaarData);
-            });
+    private void sendNotifications(List<StatusUpdate> statusUpdates, Map<String, Product> products) {
+        var cfg = ConfigManager.get().trackedOrders;
+        if(!cfg.enabled) {
+            return;
+        }
+
+        Map<GroupKey, List<TrackedOrder>> orderGroups = this.trackedOrders.stream()
+            .collect(Collectors.groupingBy(order -> new GroupKey(
+                order.productName,
+                order.type,
+                order.pricePerUnit
+            )));
+        Map<GroupKey, List<StatusUpdate>> statusGroups = statusUpdates.stream()
+            .collect(Collectors.groupingBy(update -> new GroupKey(
+                update.order().productName,
+                update.order().type,
+                update.order().pricePerUnit
+            )));
+
+        for(var entry : statusGroups.entrySet()) {
+            var key = entry.getKey();
+            var updates = entry.getValue();
+            var orders = orderGroups.get(key);
+            
+            if(orders.size() == 1) {
+                var statusUpdate = updates.getFirst();
+                if(this.shouldNotify(statusUpdate)) {
+                    Notifier.notifyOrderStatus(statusUpdate, bazaarData);
+                }
+                continue;
+            }
+
+            this.processGroupNotification(key, orders, updates, products);
+        }
+    }
+
+    private void processGroupNotification(
+        GroupKey key,
+        List<TrackedOrder> orders,
+        List<StatusUpdate> updates,
+        Map<String,Product> products
+    ) {
+        var cfg = ConfigManager.get().trackedOrders;
+        
+        if(!cfg.groupOrders) {
+            updates.stream()
+                .filter(this::shouldNotify)
+                .forEach(update -> Notifier.notifyOrderStatus(update, bazaarData));
+            return;   
+        }
+
+        GroupStatus curr = this.getCurrentGroupStatus(key, orders, products);
+        boolean shouldNotify = switch (curr) {
+            case GroupStatus.Undercut ignored -> cfg.notifyUndercut;
+            case GroupStatus.Matched ignored -> cfg.notifyMatched;
+            case GroupStatus.SelfMatched ignored -> cfg.notifyMatched;
+        };
+
+        if (!shouldNotify) {
+            return;
+        }
+
+        GroupStatus prev = this.getPreviousGroupStatus(orders, updates);
+        
+        if(curr == null || prev == null) {
+            log.warn("Group ({}) has no settled status, skipping group notification: previous status: {}, current status: {}", key, prev, curr);
+            return;
+        }
+
+        Notifier.notifyGroupOrderStatus(key, orders, curr, prev, this.bazaarData);
+    }
+
+
+    private @Nullable GroupStatus getCurrentGroupStatus(GroupKey key, List<TrackedOrder> orders, Map<String,Product> products) {
+        boolean hasMatched = orders.stream().anyMatch(order -> order.status instanceof OrderStatus.Matched);
+        boolean hasUndercut = orders.stream().anyMatch(order -> order.status instanceof OrderStatus.Undercut);
+        boolean hasUnknown = orders.stream().anyMatch(order -> order.status instanceof OrderStatus.Unknown);
+
+        if(hasUnknown) {
+            log.warn("Group ({}) has Unknown-status order after poll. Likely unresolved product name, skipping group notification", key);
+            return null;
+        }
+
+        if(hasMatched && hasUndercut) {
+            log.warn("Group ({}) has both Matched and Undercut orders. This must be a logic error, skipping group notification", key);
+            return null;
+        }
+
+        // either matched or undercut
+        if(hasUndercut) {
+            // per definition all the orders within the `orders` list must have undercut status
+            // as well as the same (product name, type, price per unit)
+            var representativeOrder = orders.getFirst();
+            var undercutAmount = ((OrderStatus.Undercut) representativeOrder.status).amount;
+            return new GroupStatus.Undercut(undercutAmount);
+        }
+
+        int bucketOrderCount = bazaarData.getBucketOrderCount(key.productName, key.type, key.pricePerUnit);
+        if(bucketOrderCount == -1) {
+            log.warn("Group ({}) has no orders at the given price per unit, skipping group notification", key);
+            return null;
+        }
+
+        return orders.size() == bucketOrderCount ? new GroupStatus.SelfMatched() : new GroupStatus.Matched();
+    }
+
+    private @Nullable GroupStatus getPreviousGroupStatus(List<TrackedOrder> orders, List<StatusUpdate> updates) {
+        Map<TrackedOrder, OrderStatus> prevStatuses = orders.stream()
+            .collect(Collectors.toMap(order -> order, order -> order.status));
+
+        updates.stream().forEach(update -> prevStatuses.put(update.order(), update.prev()));
+
+        var values = prevStatuses.values();
+
+        if (values.stream().anyMatch(status -> status instanceof OrderStatus.Undercut)) {
+            // `amount` MUST be identical across all orders in the group
+            double amount = values.stream()
+                .filter(status -> status instanceof OrderStatus.Undercut)
+                .map(status -> ((OrderStatus.Undercut) status).amount)
+                .findFirst()
+                .orElseThrow();
+            return new GroupStatus.Undercut(amount);
+        }
+
+        if (values.stream().anyMatch(status -> status instanceof OrderStatus.Matched)) {
+            return new GroupStatus.Matched();
+        }
+
+        // Top, Unknown, or mix of both -> group had no settled matched state before
+        return null;
     }
 
     public Stream<StatusUpdate> computeStatusUpdates(Map<String, Product> products) {
@@ -329,6 +455,9 @@ public class TrackedOrderManager {
 
         public boolean showQueueInfo = true;
         public QueueDisplayMode queueDisplayMode = QueueDisplayMode.Both;
+
+        public boolean groupOrders = true;
+        public boolean includePricePerUnit = false;
 
         public OptionGroup createGroup() {
             var notifyBestGroup = new OptionGrouping(this.createNotifyBestOption())

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -50,7 +50,6 @@ public class TrackedOrderManager {
     private final List<Consumer<TrackedOrder>> onOrderAddedListeners = new ArrayList<>();
     private final List<Consumer<TrackedOrder>> onOrderRemovedListeners = new ArrayList<>();
     private final List<Runnable> onOrdersResetListeners = new ArrayList<>();
-    private final List<Consumer<StatusUpdate>> onOrderStatusUpdate = new ArrayList<>();
     private BiConsumer<List<UnfilledOrderInfo>, List<FilledOrderInfo>> onSyncCompletedCallback = null;
 
     public TrackedOrderManager(BazaarData bazaarData) {
@@ -78,10 +77,6 @@ public class TrackedOrderManager {
 
     public void afterOrderSync(BiConsumer<List<UnfilledOrderInfo>, List<FilledOrderInfo>> cb) {
         this.onSyncCompletedCallback = cb;
-    }
-
-    public void addOnOrderStatusUpdate(Consumer<StatusUpdate> listener) {
-        this.onOrderStatusUpdate.add(listener);
     }
 
     public void syncOrders(List<OrderInfo> parsedOrders) {
@@ -142,7 +137,6 @@ public class TrackedOrderManager {
     public void onBazaarUpdate(Map<String, Product> products) {
         var updates = this.computeStatusUpdates(products).peek(update -> {
             update.order().status = update.curr;
-            this.onOrderStatusUpdate.forEach(listener -> listener.accept(update));
         }).collect(Collectors.toList());
 
         this.sendNotifications(updates, products);        
@@ -224,10 +218,8 @@ public class TrackedOrderManager {
         }
 
         GroupStatus prev = this.getPreviousGroupStatus(key, orders, updates);
-
         Notifier.notifyGroupOrderStatus(key, orders, curr, prev, this.bazaarData);
     }
-
 
     private @Nullable GroupStatus getCurrentGroupStatus(GroupKey key, List<TrackedOrder> orders, Map<String,Product> products) {
         boolean hasMatched = orders.stream().anyMatch(order -> order.status instanceof OrderStatus.Matched);
@@ -293,7 +285,7 @@ public class TrackedOrderManager {
         }
 
         // Top, Unknown, or mix of both -> group had no settled matched state before
-        log.warn("Group ({}) has no settled matched state before, skipping group notification currently tracked orders: {} | updates: {}", 
+        log.debug("Group ({}) had no prior matched group state. currently tracked orders: {} | updates: {}", 
             key, orders, updates);
         return null;
     }

--- a/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/TrackedOrderManager.java
@@ -30,6 +30,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product;
 import net.minecraft.network.chat.Component;
@@ -126,59 +129,77 @@ public class TrackedOrderManager {
         }
     }
 
+    record GroupKey(String productName, OrderType type, double pricePerUnit) {}
+
+    sealed interface GroupStatus {
+        record Undercut(double amount) implements GroupStatus {}
+        record Matched() implements GroupStatus {}
+        record SelfMatched() implements GroupStatus {}
+    }
+
     public void onBazaarUpdate(Map<String, Product> products) {
-        this.trackedOrders
-            .stream()
-            .map(tracked -> {
-                var id = bazaarData.nameToId(tracked.productName);
-                if (id.isEmpty()) {
-                    log.warn(
-                        "No name -> id mapping found for product with name: '{}'",
-                        tracked.productName
-                    );
-                    return Optional.<TrackedStatus>empty();
-                }
+        var updates = this.computeStatusUpdates(products).peek(update -> {
+            update.order().status = update.curr;
+            this.onOrderStatusUpdate.forEach(listener -> listener.accept(update));
+        }).collect(Collectors.toList());
 
-                var product = Optional.ofNullable(products.get(id.get()));
-                if (product.isEmpty()) {
-                    log.warn(
-                        "No product found for item with name '{}' and mapped id '{}'",
-                        tracked.productName,
-                        id.get()
-                    );
-                    return Optional.<TrackedStatus>empty();
-                }
+        this.sendNotifications(updates, products);        
+    }
 
-                var status = this.getStatus(tracked, product.get());
-                if (status.isEmpty()) {
-                    log.debug(
-                        "Unable to determine curr for product '{}' with id '{}'",
-                        tracked.productName,
-                        id.get()
-                    );
-                    return Optional.<TrackedStatus>empty();
-                }
-
-                return Optional.of(new TrackedStatus(tracked, status.get()));
-            })
-            .flatMap(Optional::stream)
-            .filter(trackedStatus -> !trackedStatus.trackedOrder().status.sameVariant(trackedStatus.status()))
-            .forEach(trackedStatus -> {
-                var statusUpdate = new StatusUpdate(
-                    trackedStatus.trackedOrder(),
-                    trackedStatus.status(),
-                    trackedStatus.trackedOrder().status
-                );
-
-                trackedStatus.trackedOrder().status = statusUpdate.curr;
-
-                this.onOrderStatusUpdate.forEach(listener -> listener.accept(statusUpdate));
-
-                if (this.shouldNotify(statusUpdate)) {
-                    Notifier.notifyOrderStatus(statusUpdate, this.bazaarData);
-                }
+    private void sendNotifications(List<StatusUpdate> updates, Map<String, Product> products) {
+        updates.stream()
+            .filter(this::shouldNotify)
+            .forEach(update -> {
+                Notifier.notifyOrderStatus(update, this.bazaarData);
             });
     }
+
+    public Stream<StatusUpdate> computeStatusUpdates(Map<String, Product> products) {
+        return this.trackedOrders
+            .stream()
+            .map(order -> this.getTrackedStatus(order, products))
+            .flatMap(Optional::stream)
+            .filter(trackedStatus -> !trackedStatus.order().status.sameVariant(trackedStatus.status()))
+            .map(trackedStatus -> new StatusUpdate(
+                trackedStatus.order(),
+                trackedStatus.status(),
+                trackedStatus.order().status
+            ));
+    }
+
+       public Optional<TrackedStatus> getTrackedStatus(TrackedOrder order, Map<String, Product> products) {
+        var id = bazaarData.nameToId(order.productName);
+        if (id.isEmpty()) {
+            log.warn(
+                "No name -> id mapping found for product with name: '{}'",
+                order.productName
+            );
+            return Optional.empty();
+        }
+
+        var product = Optional.ofNullable(products.get(id.get()));
+        if (product.isEmpty()) {
+            log.warn(
+                "No product found for item with name '{}' and mapped id '{}'",
+                order.productName,
+                id.get()
+            );
+            return Optional.empty();
+        }
+
+        var status = this.getStatus(order, product.get());
+        if (status.isEmpty()) {
+            log.debug(
+                "Unable to determine curr for product '{}' with id '{}'",
+                order.productName,
+                id.get()
+            );
+            return Optional.empty();
+        }
+
+        return Optional.of(new TrackedStatus(order, status.get()));
+    }
+
 
     private boolean shouldNotify(StatusUpdate update) {
         var cfg = ConfigManager.get().trackedOrders;
@@ -287,9 +308,9 @@ public class TrackedOrderManager {
         };
     }
 
-    private record TrackedStatus(TrackedOrder trackedOrder, OrderStatus status) { }
+    private record TrackedStatus(TrackedOrder order, OrderStatus status) { }
 
-    public record StatusUpdate(TrackedOrder trackedOrder, OrderStatus curr, OrderStatus prev) { }
+    public record StatusUpdate(TrackedOrder order, OrderStatus curr, OrderStatus prev) { }
 
     public static class OrderManagerConfig {
 

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -181,6 +181,28 @@ public class BazaarData {
         return queueInfo.ordersAhead > 0 ? Optional.of(queueInfo) : Optional.empty();
     }
 
+    /**
+     * Returns the number of orders in the bucket at the given price per unit.
+     * <p>
+     * Returns -1 if the product is not found, the order type is not found, or the price per unit is not found.
+     */
+    public int getBucketOrderCount(String productName, OrderType orderType, double pricePerUnit) {
+        var productId = this.nameToId(productName).orElse(null);
+        if (productId == null) return -1;
+        var product = this.lastProducts.get(productId);
+        if (product == null) return -1;
+
+        var relevantSummary = switch (orderType) {
+            case Buy -> Utils.getFirst(product.getSellSummary());
+            case Sell -> Utils.getFirst(product.getBuySummary());
+        };
+
+        return relevantSummary
+            .filter(summary -> summary.getPricePerUnit() == pricePerUnit)
+            .map(summary -> (int) summary.getOrders())
+            .orElse(-1);
+    }
+
     public Optional<Double> getEstimatedFillTimeMinutes(String productName, OrderType orderType, int remainingVolume) {
         if (remainingVolume <= 0) {
             return Optional.of(0.0);

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -181,28 +181,6 @@ public class BazaarData {
         return queueInfo.ordersAhead > 0 ? Optional.of(queueInfo) : Optional.empty();
     }
 
-    /**
-     * Returns the number of orders in the bucket at the given price per unit.
-     * <p>
-     * Returns -1 if the product is not found, the order type is not found, or the price per unit is not found.
-     */
-    public int getBucketOrderCount(String productName, OrderType orderType, double pricePerUnit) {
-        var productId = this.nameToId(productName).orElse(null);
-        if (productId == null) return -1;
-        var product = this.lastProducts.get(productId);
-        if (product == null) return -1;
-
-        var relevantSummary = switch (orderType) {
-            case Buy -> Utils.getFirst(product.getSellSummary());
-            case Sell -> Utils.getFirst(product.getBuySummary());
-        };
-
-        return relevantSummary
-            .filter(summary -> summary.getPricePerUnit() == pricePerUnit)
-            .map(summary -> (int) summary.getOrders())
-            .orElse(-1);
-    }
-
     public Optional<Double> getEstimatedFillTimeMinutes(String productName, OrderType orderType, int remainingVolume) {
         if (remainingVolume <= 0) {
             return Optional.of(0.0);

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -3,6 +3,8 @@ package com.github.lutzluca.btrbz.utils;
 import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.core.AlertManager.Alert;
 import com.github.lutzluca.btrbz.core.OrderProtectionManager.ValidationResult;
+import com.github.lutzluca.btrbz.core.TrackedOrderManager.GroupKey;
+import com.github.lutzluca.btrbz.core.TrackedOrderManager.GroupStatus;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.Action;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.StatusUpdate;
 import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.ResolvedAlertArgs;
@@ -13,6 +15,8 @@ import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Top;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Undercut;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
 import com.github.lutzluca.btrbz.data.OrderModels.TrackedOrder;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -308,4 +312,98 @@ public class Notifier {
 
         Notifier.notifyPlayer(msg);
     }
+
+    public static void notifyGroupOrderStatus(
+    GroupKey key,
+    List<TrackedOrder> allOrders,
+    GroupStatus currGroupStatus,
+    GroupStatus prevGroupStatus,
+    BazaarData bazaarData
+) {
+    var cfg = ConfigManager.get().trackedOrders;
+    int totalVolume = allOrders.stream().mapToInt(o -> o.volume).sum();
+    int groupSize = allOrders.size();
+
+    var msg = switch (currGroupStatus) {
+        case GroupStatus.Undercut undercut -> {
+            SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
+
+            var statusPart = Component.empty()
+                .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
+                .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(
+                    Utils.formatDecimal(undercut.amount(), 1, true) + " coins!")
+                    .withStyle(ChatFormatting.GOLD));
+
+            var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+
+            if (cfg.showQueueInfo) {
+                bazaarData.calculateQueuePosition(
+                    key.productName(), key.type(), key.pricePerUnit()
+                ).ifPresent(info -> {
+                    m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
+                    m.append(GameUtils.buildQueueComponent(
+                        info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
+                });
+            }
+
+            yield m;
+        }
+
+        case GroupStatus.Matched ignored -> {
+            SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+
+            var statusPart = Component.empty()
+                .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
+
+            var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+
+            // For groups, Top→Matched is structurally impossible, so we always
+            // show queue info — there's no prior "sole best" state to special-case.
+            if (cfg.showQueueInfo) {
+                bazaarData.calculateQueuePosition(
+                    key.productName(), key.type(), key.pricePerUnit(), true
+                ).ifPresent(info -> {
+                    int displayOrders = Math.max(0, info.ordersAhead - groupSize);
+                    int displayItems = Math.max(0, info.itemsAhead - totalVolume);
+
+                    if (displayOrders > 0 || displayItems > 0) {
+                        m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
+                        m.append(GameUtils.buildQueueComponent(
+                            displayOrders, displayItems, cfg.queueDisplayMode));
+                    }
+                });
+            }
+
+            yield m;
+        }
+
+        case GroupStatus.SelfMatched ignored -> {
+            SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+
+            var statusPart = Component.empty()
+                .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal("SELF-MATCHED!").withStyle(ChatFormatting.BLUE));
+
+            // No queue info — you own the entire bucket, nobody is ahead of you
+            yield fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+        }
+    };
+
+    if (currGroupStatus instanceof GroupStatus.Matched
+        || currGroupStatus instanceof GroupStatus.SelfMatched) {
+        if (cfg.gotoOnMatched != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnMatched, key.productName());
+        }
+    }
+
+    if (currGroupStatus instanceof GroupStatus.Undercut) {
+        if (cfg.gotoOnUndercut != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnUndercut, key.productName());
+        }
+    }
+
+    notifyPlayer(msg);
+}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -20,6 +20,9 @@ import com.github.lutzluca.btrbz.data.OrderModels.TrackedOrder;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.jetbrains.annotations.Nullable;
+
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -283,8 +286,8 @@ public class Notifier {
         int volume,
         String productName,
         Component statusPart,
-        @org.jetbrains.annotations.Nullable Integer groupSize,
-        @org.jetbrains.annotations.Nullable Double price,
+        @Nullable Integer groupSize,
+        @Nullable Double price,
         OrderManagerConfig cfg
     ) {
         var orderString = switch (type) {
@@ -345,96 +348,98 @@ public class Notifier {
     }
 
     public static void notifyGroupOrderStatus(
-    GroupKey key,
-    List<TrackedOrder> allOrders,
-    GroupStatus currGroupStatus,
-    GroupStatus prevGroupStatus,
-    BazaarData bazaarData
-) {
-    var cfg = ConfigManager.get().trackedOrders;
-    int totalVolume = allOrders.stream().mapToInt(o -> o.volume).sum();
-    int groupSize = allOrders.size();
+        GroupKey key,
+        List<TrackedOrder> allOrders,
+        GroupStatus currGroupStatus,
+        GroupStatus prevGroupStatus,
+        BazaarData bazaarData
+    ) {
+        var cfg = ConfigManager.get().trackedOrders;
+        int totalVolume = allOrders.stream().mapToInt(o -> o.volume).sum();
+        int groupSize = allOrders.size();
 
-    var msg = switch (currGroupStatus) {
-        case GroupStatus.Undercut undercut -> {
-            SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
+        var msg = switch (currGroupStatus) {
+            case GroupStatus.Undercut undercut -> {
+                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
 
-            var statusPart = Component.empty()
-                .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
-                .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal(
-                    Utils.formatDecimal(undercut.amount(), 1, true) + " coins!")
-                    .withStyle(ChatFormatting.GOLD));
+                var statusPart = Component.empty()
+                    .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
+                    .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(
+                        Utils.formatDecimal(undercut.amount(), 1, true) + " coins!")
+                        .withStyle(ChatFormatting.GOLD));
 
-            var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+                var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
 
-            if (cfg.showQueueInfo) {
-                bazaarData.calculateQueuePosition(
-                    key.productName(), key.type(), key.pricePerUnit()
-                ).ifPresent(info -> {
-                    m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
-                    m.append(GameUtils.buildQueueComponent(
-                        info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
-                });
-            }
-
-            yield m;
-        }
-
-        case GroupStatus.Matched ignored -> {
-            SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-
-            var statusPart = Component.empty()
-                .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
-
-            var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
-
-            // For groups, Top→Matched is structurally impossible, so we always
-            // show queue info — there's no prior "sole best" state to special-case.
-            if (cfg.showQueueInfo) {
-                bazaarData.calculateQueuePosition(
-                    key.productName(), key.type(), key.pricePerUnit(), true
-                ).ifPresent(info -> {
-                    int displayOrders = Math.max(0, info.ordersAhead - groupSize);
-                    int displayItems = Math.max(0, info.itemsAhead - totalVolume);
-
-                    if (displayOrders > 0 || displayItems > 0) {
+                if (cfg.showQueueInfo) {
+                    bazaarData.calculateQueuePosition(
+                        key.productName(), key.type(), key.pricePerUnit()
+                    ).ifPresent(info -> {
                         m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
                         m.append(GameUtils.buildQueueComponent(
-                            displayOrders, displayItems, cfg.queueDisplayMode));
-                    }
-                });
+                            info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
+                    });
+                }
+
+                yield m;
             }
 
-            yield m;
+            case GroupStatus.Matched ignored -> {
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+
+                String verb = groupSize > 1 ? "were " : "was ";
+
+                var statusPart = Component.empty()
+                    .append(Component.literal(verb).withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
+
+                var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+
+                // For groups, Top->Matched is structurally impossible, so we always
+                // show queue info — there's no prior "sole best" state to special-case.
+                if (cfg.showQueueInfo) {
+                    bazaarData.calculateQueuePosition(
+                        key.productName(), key.type(), key.pricePerUnit(), true
+                    ).ifPresent(info -> {
+                        int displayOrders = Math.max(0, info.ordersAhead - groupSize);
+                        int displayItems = Math.max(0, info.itemsAhead - totalVolume);
+
+                        if (displayOrders > 0 || displayItems > 0) {
+                            m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
+                            m.append(GameUtils.buildQueueComponent(
+                                displayOrders, displayItems, cfg.queueDisplayMode));
+                        }
+                    });
+                }
+
+                yield m;
+            }
+
+            case GroupStatus.SelfMatched ignored -> {
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+
+                var statusPart = Component.empty()
+                    .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal("SELF-MATCHED!").withStyle(ChatFormatting.BLUE));
+
+                // No queue info — you own the entire bucket, nobody is ahead of you
+                yield fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+            }
+        };
+
+        if (currGroupStatus instanceof GroupStatus.Matched
+            || currGroupStatus instanceof GroupStatus.SelfMatched) {
+            if (cfg.gotoOnMatched != Action.None) {
+                applyGotoAction(msg, cfg.gotoOnMatched, key.productName());
+            }
         }
 
-        case GroupStatus.SelfMatched ignored -> {
-            SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-
-            var statusPart = Component.empty()
-                .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("SELF-MATCHED!").withStyle(ChatFormatting.BLUE));
-
-            // No queue info — you own the entire bucket, nobody is ahead of you
-            yield fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
+        if (currGroupStatus instanceof GroupStatus.Undercut) {
+            if (cfg.gotoOnUndercut != Action.None) {
+                applyGotoAction(msg, cfg.gotoOnUndercut, key.productName());
+            }
         }
-    };
 
-    if (currGroupStatus instanceof GroupStatus.Matched
-        || currGroupStatus instanceof GroupStatus.SelfMatched) {
-        if (cfg.gotoOnMatched != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnMatched, key.productName());
-        }
+        notifyPlayer(msg);
     }
-
-    if (currGroupStatus instanceof GroupStatus.Undercut) {
-        if (cfg.gotoOnUndercut != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnUndercut, key.productName());
-        }
-    }
-
-    notifyPlayer(msg);
-}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -113,7 +113,8 @@ public class Notifier {
             case GroupStatus.Undercut undercut -> {
                 SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
                 var undercutMsg = groupMsg(key, groupSize, totalVolume, cfg,
-                    Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED)
+                    Component.literal("were ").withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
                         .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
                         .append(Component.literal(Utils.formatDecimal(undercut.amount(), 1, true) + " coins!").withStyle(ChatFormatting.GOLD)));
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -1,6 +1,19 @@
 package com.github.lutzluca.btrbz.utils;
 
-import com.github.lutzluca.btrbz.data.BazaarData;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import lombok.extern.slf4j.Slf4j;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.ClickEvent.RunCommand;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent.ShowText;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.sounds.SoundEvents;
+
 import com.github.lutzluca.btrbz.core.AlertManager.Alert;
 import com.github.lutzluca.btrbz.core.OrderProtectionManager.ValidationResult;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.GroupKey;
@@ -10,27 +23,13 @@ import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.Act
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.StatusUpdate;
 import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.ResolvedAlertArgs;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Matched;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Top;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus.Undercut;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
 import com.github.lutzluca.btrbz.data.OrderModels.TrackedOrder;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.jetbrains.annotations.Nullable;
-
-import lombok.extern.slf4j.Slf4j;
-import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.ClickEvent.RunCommand;
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.HoverEvent.ShowText;
-import net.minecraft.network.chat.MutableComponent;
-import net.minecraft.sounds.SoundEvents;
 
 @Slf4j
 public class Notifier {
@@ -43,6 +42,190 @@ public class Notifier {
         }
         log.info("Failed to send message '{}' to player (client or player null)", msg.getString());
         return false;
+    }
+
+    public static void notifyOrderStatus(StatusUpdate update, BazaarData bazaarData) {
+        var cfg = ConfigManager.get().trackedOrders;
+        var order = update.order();
+        var status = update.curr();
+
+        MutableComponent msg = switch (status) {
+            case Top ignored -> {
+                SoundUtil.playSoundIf(cfg.soundBest, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+
+                yield update.prev() instanceof OrderStatus.Unknown
+                    ? singleMsg(order, cfg, Component.literal("is the ").withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal("BEST Order!").withStyle(ChatFormatting.GREEN)))
+                    : singleMsg(order, cfg, Component.literal("has ").withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal("REGAINED BEST Order!").withStyle(ChatFormatting.GREEN)));
+            }
+            case Matched ignored -> {
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+                var matchedMsg = singleMsg(order, cfg, Component.literal("was ").withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE)));
+
+                if (cfg.showQueueInfo && !(update.prev() instanceof OrderStatus.Top)) {
+                    bazaarData.calculateQueuePosition(order.productName, order.type, order.pricePerUnit, true)
+                        .ifPresent(info -> appendQueueInfo(matchedMsg,
+                            Math.max(0, info.ordersAhead - 1),
+                            Math.max(0, info.itemsAhead - order.volume),
+                            cfg
+                        ));
+                }
+                yield matchedMsg;
+            }
+            case Undercut undercut -> {
+                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
+                var undercutMsg = singleMsg(order, cfg, Component.literal("was ").withStyle(ChatFormatting.GRAY)
+                    .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
+                    .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
+                    .append(Component.literal(Utils.formatDecimal(undercut.amount, 1, true) + " coins!").withStyle(ChatFormatting.GOLD)));
+
+                if (cfg.showQueueInfo) {
+                    bazaarData.calculateQueuePosition(order.productName, order.type, order.pricePerUnit)
+                        .ifPresent(info -> appendQueueInfo(undercutMsg, info.ordersAhead, info.itemsAhead, cfg));
+                }
+                yield undercutMsg;
+            }
+            default -> throw new IllegalArgumentException("Unreachable status: " + status);
+        };
+
+        if (status instanceof Matched && cfg.gotoOnMatched != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnMatched, order.productName);
+        }
+        if (status instanceof Undercut && cfg.gotoOnUndercut != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnUndercut, order.productName);
+        }
+
+        notifyPlayer(msg);
+    }
+
+    public static void notifyGroupOrderStatus(
+        GroupKey key, List<TrackedOrder> allOrders,
+        GroupStatus curr, GroupStatus prev,
+        BazaarData bazaarData
+    ) {
+        var cfg = ConfigManager.get().trackedOrders;
+        int groupSize = allOrders.size();
+        int totalVolume = allOrders.stream().mapToInt(o -> o.volume).sum();
+
+        MutableComponent msg = switch (curr) {
+            case GroupStatus.Undercut undercut -> {
+                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
+                var undercutMsg = groupMsg(key, groupSize, totalVolume, cfg,
+                    Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED)
+                        .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(Utils.formatDecimal(undercut.amount(), 1, true) + " coins!").withStyle(ChatFormatting.GOLD)));
+
+                if (cfg.showQueueInfo) {
+                    bazaarData.calculateQueuePosition(key.productName(), key.type(), key.pricePerUnit())
+                        .ifPresent(info -> appendQueueInfo(undercutMsg, info.ordersAhead, info.itemsAhead, cfg));
+                }
+                
+                yield undercutMsg;
+            }
+            case GroupStatus.Matched ignored -> {
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+                var matchedMsg = groupMsg(key, groupSize, totalVolume, cfg,
+                    Component.literal("were ").withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE)));
+
+                if (cfg.showQueueInfo) {
+                    bazaarData.calculateQueuePosition(key.productName(), key.type(), key.pricePerUnit(), true)
+                        .ifPresent(info -> appendQueueInfo(matchedMsg,
+                            Math.max(0, info.ordersAhead - groupSize),
+                            Math.max(0, info.itemsAhead - totalVolume),
+                            cfg
+                        ));
+                }
+                
+                yield matchedMsg;
+            }
+            case GroupStatus.SelfMatched ignored -> {
+                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
+                
+                yield groupMsg(key, groupSize, totalVolume, cfg,
+                    Component.literal("were ").withStyle(ChatFormatting.GRAY)
+                        .append(Component.literal("SELF-MATCHED!").withStyle(ChatFormatting.BLUE)));
+            }
+        };
+
+        if ((curr instanceof GroupStatus.Matched || curr instanceof GroupStatus.SelfMatched) && cfg.gotoOnMatched != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnMatched, key.productName());
+        }
+        if (curr instanceof GroupStatus.Undercut && cfg.gotoOnUndercut != Action.None) {
+            applyGotoAction(msg, cfg.gotoOnUndercut, key.productName());
+        }
+
+        notifyPlayer(msg);
+    }
+
+    private static MutableComponent singleMsg(TrackedOrder order, OrderManagerConfig cfg, Component statusPart) {
+        var orderString = order.type == OrderType.Buy ? "Buy order" : "Sell offer";
+        var msg = prefix()
+            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
+            .append(Component.literal(" for ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(order.volume + "x").withStyle(ChatFormatting.LIGHT_PURPLE))
+            .append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(order.productName).withStyle(ChatFormatting.YELLOW));
+
+        if (cfg.includePricePerUnit) {
+            msg.append(Component.literal(" at ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(Utils.formatDecimal(order.pricePerUnit, 1, true)).withStyle(ChatFormatting.GOLD))
+                .append(Component.literal(" coins").withStyle(ChatFormatting.GRAY));
+        }
+
+        return msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY)).append(statusPart);
+    }
+
+    private static MutableComponent groupMsg(GroupKey key, int groupSize, int totalVolume, OrderManagerConfig cfg, Component statusPart) {
+        var orderString = key.type() == OrderType.Buy ? "Buy orders" : "Sell offers";
+        
+        var msg = prefix()
+            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(groupSize + "x ").withStyle(ChatFormatting.AQUA))
+            .append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
+            .append(Component.literal(" for ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(totalVolume + "x total").withStyle(ChatFormatting.LIGHT_PURPLE))
+            .append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(key.productName()).withStyle(ChatFormatting.YELLOW));
+
+        if (cfg.includePricePerUnit) {
+            msg.append(Component.literal(" at ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(Utils.formatDecimal(key.pricePerUnit(), 1, true)).withStyle(ChatFormatting.GOLD))
+                .append(Component.literal(" coins").withStyle(ChatFormatting.GRAY));
+        }
+
+        return msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY)).append(statusPart);
+    }
+
+    private static void appendQueueInfo(MutableComponent msg, int ordersAhead, int itemsAhead, OrderManagerConfig cfg) {
+        if (ordersAhead <= 0 && itemsAhead <= 0) {
+            return;
+        }
+
+        msg.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY))
+            .append(GameUtils.buildQueueComponent(ordersAhead, itemsAhead, cfg.queueDisplayMode));
+    }
+
+    private static void applyGotoAction(MutableComponent msg, Action action, String productName) {
+        if (action == Action.Item) {
+            msg.append(Component.literal(" [Go To Item]")
+                .withStyle(ChatFormatting.DARK_AQUA)
+                .withStyle(style -> style
+                    .withClickEvent(new RunCommand("/bz " + productName))
+                    .withHoverEvent(new ShowText(Component.empty()
+                        .append(Component.literal("Open ").withStyle(ChatFormatting.GRAY))
+                        .append(Component.literal(productName).withStyle(ChatFormatting.AQUA))
+                        .append(Component.literal(" in the Bazaar").withStyle(ChatFormatting.GRAY))))));
+            return;
+        }
+        msg.append(Component.literal(" [Go To Orders]")
+            .withStyle(ChatFormatting.DARK_AQUA)
+            .withStyle(style -> style
+                .withClickEvent(new RunCommand("/managebazaarorders"))
+                .withHoverEvent(new ShowText(Component.literal("Opens the Bazaar order screen")))));
     }
 
     public static void notifyAlertRegistered(ResolvedAlertArgs cmd) {
@@ -62,7 +245,7 @@ public class Notifier {
 
     public static void notifyPriceReached(Alert alert, Optional<Double> price) {
         SoundUtil.playSoundIf(ConfigManager.get().alert.soundOnAlert, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
-        
+
         String priceText = price
             .map(p -> Utils.formatDecimal(p, 1, true) + " coins. ")
             .orElse("currently has no listed price. ");
@@ -106,7 +289,6 @@ public class Notifier {
         notifyPlayer(msg);
     }
 
-
     public static void notifyInvalidProduct(Alert alert) {
         Component msg = prefix()
             .append(Component.literal("The price of ").withStyle(ChatFormatting.GRAY))
@@ -146,196 +328,9 @@ public class Notifier {
                 .withHoverEvent(new ShowText(Component.literal("Run /" + cmd))));
         notifyPlayer(prefix().append(msg.withStyle(ChatFormatting.WHITE)));
     }
-    
-    /**
-     * Assumes the parent notification condition (e.g. notifyBest) is already met by the caller.
-     * Only checks the associated sound toggles before playing.
-     */
-    public static void notifyOrderStatus(StatusUpdate update, BazaarData bazaarData) {
-        var order = update.order();
-        var status = update.curr();
-
-        var cfg = ConfigManager.get().trackedOrders;
-
-        MutableComponent msg = switch (status) {
-            case Top ignored -> {
-                SoundUtil.playSoundIf(cfg.soundBest, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-                if (update.prev() instanceof OrderStatus.Unknown) {
-                    yield bestMsg(order, cfg);
-                }
-                yield reclaimBestMsg(order, cfg);
-            }
-            case Matched ignored -> {
-                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-                yield matchedMsg(order, update.prev(), bazaarData, cfg);
-            }
-            case Undercut undercut -> {
-                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
-                yield undercutMsg(order, undercut.amount, bazaarData, cfg);
-            }
-            default -> throw new IllegalArgumentException("Unreachable status: " + status);
-        };
-
-        if (status instanceof Matched && cfg.gotoOnMatched != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnMatched, order.productName);
-        }
-
-        if (status instanceof Undercut && cfg.gotoOnUndercut != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnUndercut, order.productName);
-        }
-
-        notifyPlayer(msg);
-    }
-
-    private static void applyGotoAction(MutableComponent msg, Action action, String productName) {
-        if (action == Action.Item) {
-            msg.append(Component.literal(" [Go To Item]")
-                .withStyle(ChatFormatting.DARK_AQUA)
-                .withStyle(style -> style
-                    .withClickEvent(new RunCommand("/bz " + productName))
-                    .withHoverEvent(new ShowText(Component
-                        .literal("Open ")
-                        .withStyle(ChatFormatting.GRAY)
-                        .append(Component.literal(productName).withStyle(ChatFormatting.AQUA))
-                        .append(Component.literal(" in the Bazaar").withStyle(ChatFormatting.GRAY))))));
-            return;
-        }
-
-        msg.append(Component.literal(" [Go To Orders]")
-            .withStyle(ChatFormatting.DARK_AQUA)
-            .withStyle(style -> style
-                .withClickEvent(new RunCommand("/managebazaarorders"))
-                .withHoverEvent(new ShowText(Component.literal("Opens the Bazaar order screen")))));
-    }
-
-
-    private static MutableComponent bestMsg(TrackedOrder order, OrderManagerConfig cfg) {
-        var status = Component
-            .empty()
-            .append(Component.literal("is the ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal("BEST Order!").withStyle(ChatFormatting.GREEN));
-        return fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
-    }
-
-    private static MutableComponent reclaimBestMsg(TrackedOrder order, OrderManagerConfig cfg) {
-        var status = Component
-            .empty()
-            .append(Component.literal("has ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal("REGAINED BEST Order!").withStyle(ChatFormatting.GREEN));
-        return fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
-    }
-
-    private static MutableComponent matchedMsg(TrackedOrder order, OrderStatus prevStatus, BazaarData bazaarData, OrderManagerConfig cfg) {
-        var status = Component
-            .empty()
-            .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
-
-        MutableComponent msg = fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
-
-        // Top -> Matched: the player was already the sole best order, so any new same-price
-        // orders arrived after and are behind in the FIFO queue. The API summary only gives
-        // aggregate (orders, volume) per price bucket with no intra-bucket ordering, so
-        // showing them as "ahead" would be misleading. Skip queue info for this transition.
-        if (cfg.showQueueInfo && !(prevStatus instanceof OrderStatus.Top)) {
-            bazaarData.calculateQueuePosition(
-                order.productName, order.type, order.pricePerUnit, true
-            ).ifPresent(info -> {
-                int displayOrders = Math.max(0, info.ordersAhead - 1);
-                int displayItems = Math.max(0, info.itemsAhead - order.volume);
-
-                msg.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
-                msg.append(GameUtils.buildQueueComponent(displayOrders, displayItems, cfg.queueDisplayMode));
-            });
-        }
-
-        return msg;
-    }
-
-    private static MutableComponent undercutMsg(TrackedOrder order, double undercutAmount, BazaarData bazaarData, OrderManagerConfig cfg) {
-        var status = Component
-            .empty()
-            .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
-            .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
-            .append(Component
-                .literal(Utils.formatDecimal(undercutAmount, 1, true))
-                .withStyle(ChatFormatting.GOLD))
-            .append(Component.literal(" coins!").withStyle(ChatFormatting.GRAY));
-
-        MutableComponent msg = fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
-
-        if (cfg.showQueueInfo) {
-            bazaarData.calculateQueuePosition(
-                order.productName, order.type, order.pricePerUnit
-            ).ifPresent(info -> {
-                msg.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
-                msg.append(GameUtils.buildQueueComponent(info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
-            });
-        }
-
-        return msg;
-    }
-
-    public static MutableComponent prefix() {
-        return Component.literal("[BtrBz] ").withStyle(ChatFormatting.GOLD);
-    }
-
-    private static MutableComponent fillBaseMessage(
-        OrderType type,
-        int volume,
-        String productName,
-        Component statusPart,
-        @Nullable Integer groupSize,
-        @Nullable Double price,
-        OrderManagerConfig cfg
-    ) {
-        var orderString = switch (type) {
-            case Buy -> groupSize != null && groupSize > 1 ? "Buy orders" : "Buy order";
-            case Sell -> groupSize != null && groupSize > 1 ? "Sell offers" : "Sell offer";
-        };
-
-        var msg = prefix()
-            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY));
-
-        if (groupSize != null && groupSize > 1) {
-            msg.append(Component.literal(groupSize + "x ").withStyle(ChatFormatting.AQUA));
-        }
-
-        msg.append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
-            .append(Component.literal(" for ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal(String.valueOf(volume)).withStyle(ChatFormatting.LIGHT_PURPLE));
-
-        if (groupSize != null && groupSize > 1) {
-            msg.append(Component.literal("x total").withStyle(ChatFormatting.GRAY));
-        } else {
-            msg.append(Component.literal("x").withStyle(ChatFormatting.GRAY));
-        }
-
-        msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal(productName).withStyle(ChatFormatting.YELLOW));
-
-        if (cfg.includePricePerUnit && price != null) {
-            msg.append(Component.literal(" at ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal(Utils.formatDecimal(price, 1, true)).withStyle(ChatFormatting.GOLD))
-                .append(Component.literal(" coins").withStyle(ChatFormatting.GRAY));
-        }
-
-        return msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY)).append(statusPart);
-    }
-
-    private static MutableComponent fillGroupBaseMessage(
-        GroupKey key,
-        int groupSize,
-        int totalVolume,
-        Component statusPart,
-        OrderManagerConfig cfg
-    ) {
-        return fillBaseMessage(key.type(), totalVolume, key.productName(), statusPart, groupSize, key.pricePerUnit(), cfg);
-    }
 
     public static void sendBlockedOrderMessage(ValidationResult validation) {
-        var reason = validation.reason() == null 
+        var reason = validation.reason() == null
             ? "Order blocked."
             : "Order blocked: " + validation.reason();
 
@@ -344,102 +339,10 @@ public class Notifier {
             .withStyle(ChatFormatting.RED)
             .append(Component.literal(" Hold Ctrl to override.").withStyle(ChatFormatting.GRAY));
 
-        Notifier.notifyPlayer(msg);
+        notifyPlayer(msg);
     }
 
-    public static void notifyGroupOrderStatus(
-        GroupKey key,
-        List<TrackedOrder> allOrders,
-        GroupStatus currGroupStatus,
-        GroupStatus prevGroupStatus,
-        BazaarData bazaarData
-    ) {
-        var cfg = ConfigManager.get().trackedOrders;
-        int totalVolume = allOrders.stream().mapToInt(o -> o.volume).sum();
-        int groupSize = allOrders.size();
-
-        var msg = switch (currGroupStatus) {
-            case GroupStatus.Undercut undercut -> {
-                SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
-
-                var statusPart = Component.empty()
-                    .append(Component.literal("UNDERCUT ").withStyle(ChatFormatting.RED))
-                    .append(Component.literal("by ").withStyle(ChatFormatting.GRAY))
-                    .append(Component.literal(
-                        Utils.formatDecimal(undercut.amount(), 1, true) + " coins!")
-                        .withStyle(ChatFormatting.GOLD));
-
-                var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
-
-                if (cfg.showQueueInfo) {
-                    bazaarData.calculateQueuePosition(
-                        key.productName(), key.type(), key.pricePerUnit()
-                    ).ifPresent(info -> {
-                        m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
-                        m.append(GameUtils.buildQueueComponent(
-                            info.ordersAhead, info.itemsAhead, cfg.queueDisplayMode));
-                    });
-                }
-
-                yield m;
-            }
-
-            case GroupStatus.Matched ignored -> {
-                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-
-                String verb = groupSize > 1 ? "were " : "was ";
-
-                var statusPart = Component.empty()
-                    .append(Component.literal(verb).withStyle(ChatFormatting.GRAY))
-                    .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
-
-                var m = fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
-
-                // For groups, Top->Matched is structurally impossible, so we always
-                // show queue info — there's no prior "sole best" state to special-case.
-                if (cfg.showQueueInfo) {
-                    bazaarData.calculateQueuePosition(
-                        key.productName(), key.type(), key.pricePerUnit(), true
-                    ).ifPresent(info -> {
-                        int displayOrders = Math.max(0, info.ordersAhead - groupSize);
-                        int displayItems = Math.max(0, info.itemsAhead - totalVolume);
-
-                        if (displayOrders > 0 || displayItems > 0) {
-                            m.append(Component.literal(" • queue: ").withStyle(ChatFormatting.GRAY));
-                            m.append(GameUtils.buildQueueComponent(
-                                displayOrders, displayItems, cfg.queueDisplayMode));
-                        }
-                    });
-                }
-
-                yield m;
-            }
-
-            case GroupStatus.SelfMatched ignored -> {
-                SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-
-                var statusPart = Component.empty()
-                    .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
-                    .append(Component.literal("SELF-MATCHED!").withStyle(ChatFormatting.BLUE));
-
-                // No queue info — you own the entire bucket, nobody is ahead of you
-                yield fillGroupBaseMessage(key, groupSize, totalVolume, statusPart, cfg);
-            }
-        };
-
-        if (currGroupStatus instanceof GroupStatus.Matched
-            || currGroupStatus instanceof GroupStatus.SelfMatched) {
-            if (cfg.gotoOnMatched != Action.None) {
-                applyGotoAction(msg, cfg.gotoOnMatched, key.productName());
-            }
-        }
-
-        if (currGroupStatus instanceof GroupStatus.Undercut) {
-            if (cfg.gotoOnUndercut != Action.None) {
-                applyGotoAction(msg, cfg.gotoOnUndercut, key.productName());
-            }
-        }
-
-        notifyPlayer(msg);
+    public static MutableComponent prefix() {
+        return Component.literal("[BtrBz] ").withStyle(ChatFormatting.GOLD);
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -144,7 +144,7 @@ public class Notifier {
      * Only checks the associated sound toggles before playing.
      */
     public static void notifyOrderStatus(StatusUpdate update, BazaarData bazaarData) {
-        var order = update.trackedOrder();
+        var order = update.order();
         var status = update.curr();
 
         var cfg = ConfigManager.get().trackedOrders;

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Notifier.java
@@ -5,6 +5,7 @@ import com.github.lutzluca.btrbz.core.AlertManager.Alert;
 import com.github.lutzluca.btrbz.core.OrderProtectionManager.ValidationResult;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.GroupKey;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.GroupStatus;
+import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.OrderManagerConfig.Action;
 import com.github.lutzluca.btrbz.core.TrackedOrderManager.StatusUpdate;
 import com.github.lutzluca.btrbz.core.commands.alert.AlertCommandParser.ResolvedAlertArgs;
@@ -153,46 +154,46 @@ public class Notifier {
 
         var cfg = ConfigManager.get().trackedOrders;
 
-        var msg = switch (status) {
+        MutableComponent msg = switch (status) {
             case Top ignored -> {
                 SoundUtil.playSoundIf(cfg.soundBest, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
                 if (update.prev() instanceof OrderStatus.Unknown) {
-                    yield bestMsg(order);
+                    yield bestMsg(order, cfg);
                 }
-                yield reclaimBestMsg(order);
+                yield reclaimBestMsg(order, cfg);
             }
             case Matched ignored -> {
                 SoundUtil.playSoundIf(cfg.soundMatched, SoundEvents.NOTE_BLOCK_CHIME, 0.5f, 1);
-                yield matchedMsg(order, update.prev(), bazaarData);
+                yield matchedMsg(order, update.prev(), bazaarData, cfg);
             }
             case Undercut undercut -> {
                 SoundUtil.playSoundIf(cfg.soundUndercut, SoundEvents.EXPERIENCE_ORB_PICKUP, 0.5f, 2);
-                yield undercutMsg(order, undercut.amount, bazaarData);
+                yield undercutMsg(order, undercut.amount, bazaarData, cfg);
             }
-            default -> throw new IllegalArgumentException("Unreachable curr: " + status);
+            default -> throw new IllegalArgumentException("Unreachable status: " + status);
         };
 
         if (status instanceof Matched && cfg.gotoOnMatched != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnMatched, order);
+            applyGotoAction(msg, cfg.gotoOnMatched, order.productName);
         }
 
         if (status instanceof Undercut && cfg.gotoOnUndercut != Action.None) {
-            applyGotoAction(msg, cfg.gotoOnUndercut, order);
+            applyGotoAction(msg, cfg.gotoOnUndercut, order.productName);
         }
 
         notifyPlayer(msg);
     }
 
-    private static void applyGotoAction(MutableComponent msg, Action action, TrackedOrder order) {
+    private static void applyGotoAction(MutableComponent msg, Action action, String productName) {
         if (action == Action.Item) {
             msg.append(Component.literal(" [Go To Item]")
                 .withStyle(ChatFormatting.DARK_AQUA)
                 .withStyle(style -> style
-                    .withClickEvent(new RunCommand("/bz " + order.productName))
+                    .withClickEvent(new RunCommand("/bz " + productName))
                     .withHoverEvent(new ShowText(Component
                         .literal("Open ")
                         .withStyle(ChatFormatting.GRAY)
-                        .append(Component.literal(order.productName).withStyle(ChatFormatting.AQUA))
+                        .append(Component.literal(productName).withStyle(ChatFormatting.AQUA))
                         .append(Component.literal(" in the Bazaar").withStyle(ChatFormatting.GRAY))))));
             return;
         }
@@ -205,35 +206,34 @@ public class Notifier {
     }
 
 
-    private static MutableComponent bestMsg(TrackedOrder order) {
+    private static MutableComponent bestMsg(TrackedOrder order, OrderManagerConfig cfg) {
         var status = Component
             .empty()
             .append(Component.literal("is the ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("BEST Order!").withStyle(ChatFormatting.GREEN));
-        return fillBaseMessage(order.type, order.volume, order.productName, status);
+        return fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
     }
 
-    private static MutableComponent reclaimBestMsg(TrackedOrder order) {
+    private static MutableComponent reclaimBestMsg(TrackedOrder order, OrderManagerConfig cfg) {
         var status = Component
             .empty()
             .append(Component.literal("has ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("REGAINED BEST Order!").withStyle(ChatFormatting.GREEN));
-        return fillBaseMessage(order.type, order.volume, order.productName, status);
+        return fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
     }
 
-    private static MutableComponent matchedMsg(TrackedOrder order, OrderStatus prevStatus, BazaarData bazaarData) {
+    private static MutableComponent matchedMsg(TrackedOrder order, OrderStatus prevStatus, BazaarData bazaarData, OrderManagerConfig cfg) {
         var status = Component
             .empty()
             .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
             .append(Component.literal("MATCHED!").withStyle(ChatFormatting.BLUE));
 
-        var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
+        MutableComponent msg = fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
 
         // Top -> Matched: the player was already the sole best order, so any new same-price
         // orders arrived after and are behind in the FIFO queue. The API summary only gives
         // aggregate (orders, volume) per price bucket with no intra-bucket ordering, so
         // showing them as "ahead" would be misleading. Skip queue info for this transition.
-        var cfg = ConfigManager.get().trackedOrders;
         if (cfg.showQueueInfo && !(prevStatus instanceof OrderStatus.Top)) {
             bazaarData.calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit, true
@@ -249,7 +249,7 @@ public class Notifier {
         return msg;
     }
 
-    private static MutableComponent undercutMsg(TrackedOrder order, double undercutAmount, BazaarData bazaarData) {
+    private static MutableComponent undercutMsg(TrackedOrder order, double undercutAmount, BazaarData bazaarData, OrderManagerConfig cfg) {
         var status = Component
             .empty()
             .append(Component.literal("was ").withStyle(ChatFormatting.GRAY))
@@ -260,9 +260,8 @@ public class Notifier {
                 .withStyle(ChatFormatting.GOLD))
             .append(Component.literal(" coins!").withStyle(ChatFormatting.GRAY));
 
-        var msg = fillBaseMessage(order.type, order.volume, order.productName, status);
+        MutableComponent msg = fillBaseMessage(order.type, order.volume, order.productName, status, null, order.pricePerUnit, cfg);
 
-        var cfg = ConfigManager.get().trackedOrders;
         if (cfg.showQueueInfo) {
             bazaarData.calculateQueuePosition(
                 order.productName, order.type, order.pricePerUnit
@@ -283,21 +282,53 @@ public class Notifier {
         OrderType type,
         int volume,
         String productName,
-        Component statusPart
+        Component statusPart,
+        @org.jetbrains.annotations.Nullable Integer groupSize,
+        @org.jetbrains.annotations.Nullable Double price,
+        OrderManagerConfig cfg
     ) {
         var orderString = switch (type) {
-            case Buy -> "Buy order";
-            case Sell -> "Sell offer";
+            case Buy -> groupSize != null && groupSize > 1 ? "Buy orders" : "Buy order";
+            case Sell -> groupSize != null && groupSize > 1 ? "Sell offers" : "Sell offer";
         };
-        return prefix()
-            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
+
+        var msg = prefix()
+            .append(Component.literal("Your ").withStyle(ChatFormatting.GRAY));
+
+        if (groupSize != null && groupSize > 1) {
+            msg.append(Component.literal(groupSize + "x ").withStyle(ChatFormatting.AQUA));
+        }
+
+        msg.append(Component.literal(orderString).withStyle(ChatFormatting.AQUA))
             .append(Component.literal(" for ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal(String.valueOf(volume)).withStyle(ChatFormatting.LIGHT_PURPLE))
-            .append(Component.literal("x ").withStyle(ChatFormatting.GRAY))
-            .append(Component.literal(productName).withStyle(ChatFormatting.YELLOW))
-            .append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
-            .append(statusPart);
+            .append(Component.literal(String.valueOf(volume)).withStyle(ChatFormatting.LIGHT_PURPLE));
+
+        if (groupSize != null && groupSize > 1) {
+            msg.append(Component.literal("x total").withStyle(ChatFormatting.GRAY));
+        } else {
+            msg.append(Component.literal("x").withStyle(ChatFormatting.GRAY));
+        }
+
+        msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY))
+            .append(Component.literal(productName).withStyle(ChatFormatting.YELLOW));
+
+        if (cfg.includePricePerUnit && price != null) {
+            msg.append(Component.literal(" at ").withStyle(ChatFormatting.GRAY))
+                .append(Component.literal(Utils.formatDecimal(price, 1, true)).withStyle(ChatFormatting.GOLD))
+                .append(Component.literal(" coins").withStyle(ChatFormatting.GRAY));
+        }
+
+        return msg.append(Component.literal(" ").withStyle(ChatFormatting.GRAY)).append(statusPart);
+    }
+
+    private static MutableComponent fillGroupBaseMessage(
+        GroupKey key,
+        int groupSize,
+        int totalVolume,
+        Component statusPart,
+        OrderManagerConfig cfg
+    ) {
+        return fillBaseMessage(key.type(), totalVolume, key.productName(), statusPart, groupSize, key.pricePerUnit(), cfg);
     }
 
     public static void sendBlockedOrderMessage(ValidationResult validation) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order grouping capability: Group multiple orders of the same product and type into a single notification when enabled
  * New config option to optionally display price-per-unit information in notifications

* **Improvements**
  * Enhanced order notification messages now display order volume and count (e.g., "Your 3x Buy orders")
  * Improved notification formatting for clearer information presentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->