### PR TITLE
refactor/draggable widget position persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Switched draggable widget position config fields to nested `Position` objects instead of separate coordinate keys
+
+### Breaking
+
+- Reset saved widget positions because the alpha-stage config layout changed from flat `x`/`y` fields to nested `Position` objects with no backward-compatibility migration
+
 ## [0.5.0-alpha] - 2026-04-08
 
 ### Added

--- a/src/main/java/com/github/lutzluca/btrbz/core/ModuleManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ModuleManager.java
@@ -78,7 +78,7 @@ public class ModuleManager {
             .stream()
             .filter(module -> module.shouldDisplay(info))
             .peek(module -> module.setDisplayed(true))
-            .flatMap(module -> module.createWidgets(info).stream())
+            .flatMap(module -> module.createWidget(info).stream())
             .toList();
 
         this.widgetManager = new WidgetManager(widgets);
@@ -98,7 +98,7 @@ public class ModuleManager {
                 );
                 module.setDisplayed(true);
             })
-            .flatMap(module -> module.createWidgets(info).stream())
+            .flatMap(module -> module.createWidget(info).stream())
             .toList();
 
         if (!newWidgets.isEmpty() && this.widgetManager != null) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigManager.java
@@ -17,12 +17,10 @@ public final class ConfigManager {
         .createBuilder(Config.class)
         .serializer(config -> GsonConfigSerializerBuilder
             .create(config)
-            .appendGsonBuilder(gsonBuilder -> gsonBuilder
-                .registerTypeAdapter(
-                    BookmarkedItem.class,
-                    new BookmarkedItem.BookmarkedItemSerializer()
-                )
-                .registerTypeAdapter(Position.class, new Position.GsonAdapter()))
+            .appendGsonBuilder(builder -> builder
+                .registerTypeAdapter(BookmarkedItem.class, new BookmarkedItem.GsonAdapter())
+                .registerTypeAdapter(Position.class, new Position.GsonAdapter())
+            )
             .setPath(FabricLoader
                 .getInstance()
                 .getConfigDir()

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigManager.java
@@ -2,6 +2,7 @@ package com.github.lutzluca.btrbz.core.config;
 
 import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.modules.BookmarkModule.BookmarkedItem;
+import com.github.lutzluca.btrbz.utils.Position;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import java.util.function.Consumer;
@@ -16,10 +17,12 @@ public final class ConfigManager {
         .createBuilder(Config.class)
         .serializer(config -> GsonConfigSerializerBuilder
             .create(config)
-            .appendGsonBuilder(gsonBuilder -> gsonBuilder.registerTypeAdapter(
-                BookmarkedItem.class,
-                new BookmarkedItem.BookmarkedItemSerializer()
-            ))
+            .appendGsonBuilder(gsonBuilder -> gsonBuilder
+                .registerTypeAdapter(
+                    BookmarkedItem.class,
+                    new BookmarkedItem.BookmarkedItemSerializer()
+                )
+                .registerTypeAdapter(Position.class, new Position.GsonAdapter()))
             .setPath(FabricLoader
                 .getInstance()
                 .getConfigDir()

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -213,10 +213,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
         widget.onItemClick((self, item, idx) -> GameUtils.runCommand("bz " + ((BookmarkedItemRenderable) item).getProductName()))
             .onReorder((self, fromIdx, toIdx) -> this.syncBookmarksFromList(self.getItems()))
             .onItemRemoved((self, item, idx) -> this.syncBookmarksFromList(self.getItems()))
-            .onDragEnd((self, pos) -> {
-                log.debug("Saving new position for BookmarkModule: {}", pos);
-                this.updateConfig(cfg -> cfg.position = pos);
-            });
+            .onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.position = pos));
 
         List<Renderable> items = this.configState.bookmarkedItems.stream()
             .map(item -> new BookmarkedItemRenderable(item.productName(), item.itemStack(), this.orderBuySet, this.orderSellSet))

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -200,7 +200,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             return Optional.of(this.list);
         }
 
-        var position = Optional.ofNullable(this.configState.position).orElse(new Position(10, 10));
+        var position = Optional.ofNullable(this.configState.position).orElse(new Position(150, 275));
 
         var widget = this.list = new ListWidget(position.x(), position.y(), 175, 200, "Bookmarked Items");
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -201,7 +201,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             return Optional.of(this.list);
         }
 
-        var position = this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).orElse(new Position(10, 10));
+        var position = this.loadConfigPosition(cfg -> cfg.position).orElse(new Position(10, 10));
 
         var widget = this.list = new ListWidget(position.x(), position.y(), 175, 200, "Bookmarked Items");
 
@@ -216,7 +216,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             .onItemRemoved((self, item, idx) -> this.syncBookmarksFromList(self.getItems()))
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for BookmarkedItemsModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
             });
 
         List<Renderable> items = this.configState.bookmarkedItems.stream()
@@ -411,7 +411,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
         // TODO option for cropping at current displayed items instead of occupying the full space
         // always
         public List<BookmarkedItem> bookmarkedItems = new ArrayList<>();
-        public Integer x, y;
+        public Position position;
         public boolean enabled = true;
         public boolean showEverywhere = true;
         public int maxVisibleChildren = 8;

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -335,7 +335,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
 
     public record BookmarkedItem(String productName, ItemStack itemStack) {
 
-        public static class BookmarkedItemSerializer implements JsonSerializer<BookmarkedItem>,
+        public static class GsonAdapter implements JsonSerializer<BookmarkedItem>,
             JsonDeserializer<BookmarkedItem> {
 
             @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -214,7 +214,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             .onReorder((self, fromIdx, toIdx) -> this.syncBookmarksFromList(self.getItems()))
             .onItemRemoved((self, item, idx) -> this.syncBookmarksFromList(self.getItems()))
             .onDragEnd((self, pos) -> {
-                log.debug("Saving new position for BookmarkedItemsModule: {}", pos);
+                log.debug("Saving new position for BookmarkModule: {}", pos);
                 this.updateConfig(cfg -> cfg.position = pos);
             });
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -196,12 +196,12 @@ public class BookmarkModule extends Module<BookMarkConfig> {
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         if (this.list != null) {
-            return List.of(this.list);
+            return Optional.of(this.list);
         }
 
-        var position = this.getConfigPosition().orElse(new Position(10, 10));
+        var position = this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).orElse(new Position(10, 10));
 
         var widget = this.list = new ListWidget(position.x(), position.y(), 175, 200, "Bookmarked Items");
 
@@ -214,14 +214,17 @@ public class BookmarkModule extends Module<BookMarkConfig> {
         widget.onItemClick((self, item, idx) -> GameUtils.runCommand("bz " + ((BookmarkedItemRenderable) item).getProductName()))
             .onReorder((self, fromIdx, toIdx) -> this.syncBookmarksFromList(self.getItems()))
             .onItemRemoved((self, item, idx) -> this.syncBookmarksFromList(self.getItems()))
-            .onDragEnd((self, pos) -> this.savePosition(pos));
+            .onDragEnd((self, pos) -> {
+                log.debug("Saving new position for BookmarkedItemsModule: {}", pos);
+                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+            });
 
         List<Renderable> items = this.configState.bookmarkedItems.stream()
             .map(item -> new BookmarkedItemRenderable(item.productName(), item.itemStack(), this.orderBuySet, this.orderSellSet))
             .collect(Collectors.toList());
         widget.setItems(items);
 
-        return List.of(widget);
+        return Optional.of(widget);
     }
 
     public boolean isBookmarked(String productName) {
@@ -237,20 +240,6 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             .map(BookmarkedItemRenderable.class::cast)
             .map(item -> new BookmarkedItem(item.getProductName(), item.getItemStack()))
             .collect(Collectors.toList()));
-    }
-
-    private Optional<Position> getConfigPosition() {
-        return Utils
-            .zipNullables(this.configState.x, this.configState.y)
-            .map(pair -> new Position(pair.getLeft(), pair.getRight()));
-    }
-
-    private void savePosition(Position pos) {
-        log.debug("Saving new position for BookmarkedItemsModule: {}", pos);
-        this.updateConfig(cfg -> {
-            cfg.x = pos.x();
-            cfg.y = pos.y();
-        });
     }
 
     public static class BookmarkedItemRenderable implements Renderable {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -14,7 +14,6 @@ import com.github.lutzluca.btrbz.utils.ScreenActionManager;
 import com.github.lutzluca.btrbz.utils.ScreenActionManager.ScreenClickRule;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
-import com.github.lutzluca.btrbz.utils.Utils;
 import com.github.lutzluca.btrbz.widgets.base.DraggableWidget;
 import com.github.lutzluca.btrbz.widgets.Renderable;
 import com.github.lutzluca.btrbz.widgets.ListWidget;
@@ -201,7 +200,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             return Optional.of(this.list);
         }
 
-        var position = this.loadConfigPosition(cfg -> cfg.position).orElse(new Position(10, 10));
+        var position = Optional.ofNullable(this.configState.position).orElse(new Position(10, 10));
 
         var widget = this.list = new ListWidget(position.x(), position.y(), 175, 200, "Bookmarked Items");
 
@@ -216,7 +215,7 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             .onItemRemoved((self, item, idx) -> this.syncBookmarksFromList(self.getItems()))
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for BookmarkedItemsModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
+                this.updateConfig(cfg -> cfg.position = pos);
             });
 
         List<Renderable> items = this.configState.bookmarkedItems.stream()

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
@@ -4,11 +4,10 @@ import com.github.lutzluca.btrbz.core.ModuleManager;
 import com.github.lutzluca.btrbz.core.ModuleManager.ModuleContext;
 import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
-import com.github.lutzluca.btrbz.utils.Utils;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.ObjIntConsumer;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -56,14 +55,11 @@ public abstract class Module<T> {
         ModuleManager.getInstance().setDirty(true);
     }
 
-    protected final Optional<Position> loadConfigPosition(Function<T, Integer> xGetter, Function<T, Integer> yGetter) {
-        return Utils.zipNullables(xGetter.apply(this.configState), yGetter.apply(this.configState)).map(Position::from);
+    protected final Optional<Position> loadConfigPosition(Function<T, Position> getter) {
+        return Optional.ofNullable(getter.apply(this.configState));
     }
 
-    protected final void saveConfigPosition(Position position, ObjIntConsumer<T> xSetter, ObjIntConsumer<T> ySetter) {
-        this.updateConfig(cfg -> {
-            xSetter.accept(cfg, position.x());
-            ySetter.accept(cfg, position.y());
-        });
+    protected final void saveConfigPosition(Position position, BiConsumer<T, Position> setter) {
+        this.updateConfig(cfg -> setter.accept(cfg, position));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
@@ -2,12 +2,9 @@ package com.github.lutzluca.btrbz.core.modules;
 
 import com.github.lutzluca.btrbz.core.ModuleManager;
 import com.github.lutzluca.btrbz.core.ModuleManager.ModuleContext;
-import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -53,13 +50,5 @@ public abstract class Module<T> {
     protected void updateConfig(Consumer<T> updater) {
         updater.accept(this.configState);
         ModuleManager.getInstance().setDirty(true);
-    }
-
-    protected final Optional<Position> loadConfigPosition(Function<T, Position> getter) {
-        return Optional.ofNullable(getter.apply(this.configState));
-    }
-
-    protected final void saveConfigPosition(Position position, BiConsumer<T, Position> setter) {
-        this.updateConfig(cfg -> setter.accept(cfg, position));
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/Module.java
@@ -2,9 +2,13 @@ package com.github.lutzluca.btrbz.core.modules;
 
 import com.github.lutzluca.btrbz.core.ModuleManager;
 import com.github.lutzluca.btrbz.core.ModuleManager.ModuleContext;
+import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
-import java.util.List;
+import com.github.lutzluca.btrbz.utils.Utils;
+import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ObjIntConsumer;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -45,10 +49,21 @@ public abstract class Module<T> {
 
     public abstract boolean shouldDisplay(ScreenInfo info);
 
-    public abstract List<DraggableWidget> createWidgets(ScreenInfo info);
+    public abstract Optional<DraggableWidget> createWidget(ScreenInfo info);
 
     protected void updateConfig(Consumer<T> updater) {
         updater.accept(this.configState);
         ModuleManager.getInstance().setDirty(true);
+    }
+
+    protected final Optional<Position> loadConfigPosition(Function<T, Integer> xGetter, Function<T, Integer> yGetter) {
+        return Utils.zipNullables(xGetter.apply(this.configState), yGetter.apply(this.configState)).map(Position::from);
+    }
+
+    protected final void saveConfigPosition(Position position, ObjIntConsumer<T> xSetter, ObjIntConsumer<T> ySetter) {
+        this.updateConfig(cfg -> {
+            xSetter.accept(cfg, position.x());
+            ySetter.accept(cfg, position.y());
+        });
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -160,10 +160,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 this::handlePriceClick
             );
 
-            this.widget.onDragEnd((self, pos) -> this.saveConfigPosition(
-                pos,
-                (cfg, savedPosition) -> cfg.signPosition = savedPosition
-            ));
+            this.widget.onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.signPosition = pos));
         }
 
         this.widget.setDraggable(true);
@@ -173,7 +170,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
     }
 
     private Optional<Position> getPosition() {
-        return this.loadConfigPosition(cfg -> cfg.signPosition);
+        return Optional.ofNullable(this.configState.signPosition);
     }
 
     private void handlePriceClick(double rawPrice, boolean copyOnly) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -141,15 +141,15 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         var prev = ScreenInfoHelper.get().getPrevInfo();
         if (!this.isEnterPriceScreen(info, prev)) {
-            return List.of();
+            return Optional.empty();
         }
         this.resolveCurrentOrderType(info, prev).ifPresent(orderType -> this.currentOrderType = orderType);
 
         if (this.currentOrderType == null) {
-            return List.of();
+            return Optional.empty();
         }
 
         var position = this.getPosition();
@@ -160,26 +160,21 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
                 this::handlePriceClick
             );
 
-            this.widget.onDragEnd((self, pos) -> this.savePosition(pos));
+            this.widget.onDragEnd((self, pos) -> this.saveConfigPosition(
+                pos,
+                (cfg, x) -> cfg.signX = x,
+                (cfg, y) -> cfg.signY = y
+            ));
         }
 
         this.widget.setDraggable(true);
 
         this.rebuildList();
-        return List.of(this.widget);
+        return Optional.of(this.widget);
     }
 
     private Optional<Position> getPosition() {
-        return Utils
-            .zipNullables(this.configState.signX, this.configState.signY)
-            .map(Position::from);
-    }
-
-    private void savePosition(Position pos) {
-        this.updateConfig(cfg -> {
-            cfg.signX = pos.x();
-            cfg.signY = pos.y();
-        });
+        return this.loadConfigPosition(cfg -> cfg.signX, cfg -> cfg.signY);
     }
 
     private void handlePriceClick(double rawPrice, boolean copyOnly) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -162,8 +162,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
 
             this.widget.onDragEnd((self, pos) -> this.saveConfigPosition(
                 pos,
-                (cfg, x) -> cfg.signX = x,
-                (cfg, y) -> cfg.signY = y
+                (cfg, savedPosition) -> cfg.signPosition = savedPosition
             ));
         }
 
@@ -174,7 +173,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
     }
 
     private Optional<Position> getPosition() {
-        return this.loadConfigPosition(cfg -> cfg.signX, cfg -> cfg.signY);
+        return this.loadConfigPosition(cfg -> cfg.signPosition);
     }
 
     private void handlePriceClick(double rawPrice, boolean copyOnly) {
@@ -220,8 +219,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
     }
 
     public static class OrderBookPriceConfig {
-        public Integer signX;
-        public Integer signY;
+        public Position signPosition;
         public boolean enabled = true;
 
         public Option.Builder<Boolean> createEnableOption() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
@@ -7,6 +7,8 @@ import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
 import com.github.lutzluca.btrbz.utils.Utils;
 import com.github.lutzluca.btrbz.widgets.LabelWidget;
+import com.github.lutzluca.btrbz.widgets.base.DraggableWidget;
+
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.OptionDescription;
 import dev.isxander.yacl3.api.OptionGroup;
@@ -32,7 +34,7 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
     }
 
     @Override
-    public Optional<com.github.lutzluca.btrbz.widgets.base.DraggableWidget> createWidget(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         List<Component> lines = List.of(
             Component.literal("Daily Limit:").withStyle(ChatFormatting.GOLD),
             Component
@@ -46,10 +48,7 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
         var widget = new LabelWidget(0, 0, lines)
             .setAutoSize(true)
             .setAlignment(LabelWidget.Alignment.CENTER)
-            .onDragEnd((self, pos) -> {
-                log.debug("Saving new position for OrderLimitModule: {}", pos);
-                this.updateConfig(cfg -> cfg.position = pos);
-            });
+            .onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.position = pos));
 
         var position = Optional.ofNullable(this.configState.position)
             .or(() -> info.getHandledScreenBounds().map(bounds -> {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
@@ -48,11 +48,11 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
             .setAlignment(LabelWidget.Alignment.CENTER)
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for OrderLimitModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
             });
 
         var position = this
-            .loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y)
+            .loadConfigPosition(cfg -> cfg.position)
             .or(() -> info.getHandledScreenBounds().map(bounds -> {
                 int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
                 int y = bounds.y() - widget.getHeight() - 25;
@@ -116,7 +116,7 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
 
     public static class OrderLimitConfig {
 
-        public Integer x, y;
+        public Position position;
 
         public boolean enabled = true;
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
@@ -32,7 +32,7 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
     }
 
     @Override
-    public List<com.github.lutzluca.btrbz.widgets.base.DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<com.github.lutzluca.btrbz.widgets.base.DraggableWidget> createWidget(ScreenInfo info) {
         List<Component> lines = List.of(
             Component.literal("Daily Limit:").withStyle(ChatFormatting.GOLD),
             Component
@@ -46,10 +46,13 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
         var widget = new LabelWidget(0, 0, lines)
             .setAutoSize(true)
             .setAlignment(LabelWidget.Alignment.CENTER)
-            .onDragEnd((self, pos) -> this.savePosition(pos));
+            .onDragEnd((self, pos) -> {
+                log.debug("Saving new position for OrderLimitModule: {}", pos);
+                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+            });
 
         var position = this
-            .getConfigPosition()
+            .loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y)
             .or(() -> info.getHandledScreenBounds().map(bounds -> {
                 int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
                 int y = bounds.y() - widget.getHeight() - 25;
@@ -58,12 +61,12 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
 
         if (position.isEmpty()) {
             log.warn("Could not determine position for OrderLimitModule widget");
-            return List.of();
+            return Optional.empty();
         }
 
         widget.setPosition(position.get().x(), position.get().y());
 
-        return List.of(widget);
+        return Optional.of(widget);
     }
 
     public void onTransaction(double transactionAmount) {
@@ -78,21 +81,6 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
         );
     }
 
-    private Optional<Position> getConfigPosition() {
-        return Utils
-            .zipNullables(this.configState.x, this.configState.y)
-            .map(pair -> new Position(pair.getLeft(), pair.getRight()));
-    }
-
-    private void savePosition(int newX, int newY) {
-        log.debug("Saving new position for OrderLimitModule: {}", new Position(newX, newY));
-
-        this.updateConfig((config) -> {
-            config.x = newX;
-            config.y = newY;
-        });
-    }
-
     private void resetOrderLimitOnNewDay() {
         long today = LocalDate.now(ZoneOffset.UTC).toEpochDay();
 
@@ -104,10 +92,6 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
                 cfg.lastResetEpochDay = today;
             });
         }
-    }
-
-    private void savePosition(Position pos) {
-        this.savePosition(pos.x(), pos.y());
     }
 
     public String formatAmount(double amount) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderLimitModule.java
@@ -48,11 +48,10 @@ public class OrderLimitModule extends Module<OrderLimitModule.OrderLimitConfig> 
             .setAlignment(LabelWidget.Alignment.CENTER)
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for OrderLimitModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
+                this.updateConfig(cfg -> cfg.position = pos);
             });
 
-        var position = this
-            .loadConfigPosition(cfg -> cfg.position)
+        var position = Optional.ofNullable(this.configState.position)
             .or(() -> info.getHandledScreenBounds().map(bounds -> {
                 int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
                 int y = bounds.y() - widget.getHeight() - 25;

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
@@ -63,7 +63,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
         this.widget = new LabelWidget(0, 0, lines);
         this.widget.setAutoSize(true)
             .setAlignment(LabelWidget.Alignment.CENTER)
-            .onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition));
+            .onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.position = pos));
 
         var position = this.getWidgetPosition(info, this.widget);
         if (position.isEmpty()) {
@@ -146,7 +146,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return Optional.ofNullable(this.configState.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
@@ -63,7 +63,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
         this.widget = new LabelWidget(0, 0, lines);
         this.widget.setAutoSize(true)
             .setAlignment(LabelWidget.Alignment.CENTER)
-            .onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y));
+            .onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition));
 
         var position = this.getWidgetPosition(info, this.widget);
         if (position.isEmpty()) {
@@ -146,7 +146,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);
@@ -155,7 +155,7 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
 
     public static class OrderValueOverlayConfig {
 
-        public Integer x, y;
+        public Position position;
 
         public boolean enabled = false;
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderValueModule.java
@@ -57,20 +57,22 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         var lines = this.getLines();
 
         this.widget = new LabelWidget(0, 0, lines);
-        this.widget.setAutoSize(true).setAlignment(LabelWidget.Alignment.CENTER).onDragEnd((self, pos) -> this.savePosition(pos));
+        this.widget.setAutoSize(true)
+            .setAlignment(LabelWidget.Alignment.CENTER)
+            .onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y));
 
         var position = this.getWidgetPosition(info, this.widget);
         if (position.isEmpty()) {
-            return List.of();
+            return Optional.empty();
         }
 
         this.widget.setPosition(position.get().x(), position.get().y());
 
-        return List.of(this.widget);
+        return Optional.of(this.widget);
     }
 
     private List<Component> getLines() {
@@ -143,25 +145,12 @@ public class OrderValueModule extends Module<OrderValueModule.OrderValueOverlayC
         );
     }
 
-    private void savePosition(Position pos) {
-        this.updateConfig(cfg -> {
-            cfg.x = pos.x();
-            cfg.y = pos.y();
-        });
-    }
-
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.getConfigPosition().or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);
         }));
-    }
-
-    private Optional<Position> getConfigPosition() {
-        return Utils
-            .zipNullables(this.configState.x, this.configState.y)
-            .map(pair -> new Position(pair.getLeft(), pair.getRight()));
     }
 
     public static class OrderValueOverlayConfig {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
@@ -32,10 +32,10 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         var screenOpt = info.getGenericContainerScreen();
         if (screenOpt.isEmpty()) {
-            return List.of();
+            return Optional.empty();
         }
 
         var screen = screenOpt.get();
@@ -46,12 +46,12 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
 
         int listedCount = this.parseListedCount(inv.getItem(SELL_INSTANTLY_SLOT)).orElse(0);
         if (listedCount <= 0) {
-            return List.of();
+            return Optional.empty();
         }
 
         var priceDiffOpt = this.computePriceDiff(productName);
         if (priceDiffOpt.isEmpty()) {
-            return List.of();
+            return Optional.empty();
         }
 
         double perItemDiff = priceDiffOpt.get();
@@ -73,13 +73,13 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
 
         var position = this.getWidgetPosition(info, widget);
         if (position.isEmpty()) {
-            return List.of();
+            return Optional.empty();
         }
 
         widget.setPosition(position.get().x(), position.get().y());
-        widget.onDragEnd((self, pos) -> this.savePosition(pos));
+        widget.onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y));
 
-        return List.of(widget);
+        return Optional.of(widget);
     }
 
     private Optional<Integer> parseListedCount(ItemStack sellStack) {
@@ -108,24 +108,11 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.getConfigPosition().or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);
         }));
-    }
-
-    private Optional<Position> getConfigPosition() {
-        return Utils
-            .zipNullables(this.configState.x, this.configState.y)
-            .map(pair -> new Position(pair.getLeft(), pair.getRight()));
-    }
-
-    private void savePosition(Position pos) {
-        this.updateConfig(cfg -> {
-            cfg.x = pos.x();
-            cfg.y = pos.y();
-        });
     }
 
     public static class PriceDiffConfig {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
@@ -77,7 +77,7 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
         }
 
         widget.setPosition(position.get().x(), position.get().y());
-        widget.onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition));
+        widget.onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.position = pos));
 
         return Optional.of(widget);
     }
@@ -108,7 +108,7 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return Optional.ofNullable(this.configState.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/PriceDiffModule.java
@@ -77,7 +77,7 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
         }
 
         widget.setPosition(position.get().x(), position.get().y());
-        widget.onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y));
+        widget.onDragEnd((self, pos) -> this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition));
 
         return Optional.of(widget);
     }
@@ -108,7 +108,7 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info, LabelWidget widget) {
-        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             int x = bounds.x() + (bounds.width() - widget.getWidth()) / 2;
             int y = bounds.y() - widget.getHeight() - 15;
             return new Position(x, y);
@@ -118,7 +118,7 @@ public class PriceDiffModule extends Module<PriceDiffConfig> {
     public static class PriceDiffConfig {
 
         public boolean enabled = true;
-        public Integer x, y;
+        public Position position;
 
         public Option.Builder<Boolean> createEnabledOption() {
             return Option

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
@@ -125,14 +125,14 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         if (this.list != null) {
-            return List.of(this.list);
+            return Optional.of(this.list);
         }
 
         var position = this.getWidgetPosition(info);
         if (position.isEmpty()) {
-            return List.of();
+            return Optional.empty();
         }
 
         this.list = new ListWidget(
@@ -147,7 +147,10 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
             .setRemovable(false)
             .setReorderable(false)
             .setMaxVisibleItems(this.configState.maxVisibleChildren)
-            .onDragEnd((self, pos) -> this.savePosition(pos));
+            .onDragEnd((self, pos) -> {
+                log.debug("Saving new position for TrackedOrdersListModule: {}", pos);
+                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+            });
 
         this.list.onHoverChange((self, oldIdx, newIdx) -> {
             var oldEntry = self.getItem(oldIdx)
@@ -172,29 +175,17 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
 
         this.initializeList();
 
-        return List.of(this.list);
-    }
-
-    private void savePosition(Position pos) {
-        log.debug("Saving new position for TrackedOrdersListModule: {}", pos);
-        this.updateConfig(cfg -> {
-            cfg.x = pos.x();
-            cfg.y = pos.y();
-        });
+        return Optional.of(this.list);
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info) {
-        return this.getConfigPosition().or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
             var x = bounds.x() + bounds.width();
             var y = bounds.y();
             var padding = 20;
 
             return new Position(x + padding, y);
         }));
-    }
-
-    private Optional<Position> getConfigPosition() {
-        return Utils.zipNullables(this.configState.x, this.configState.y).map(Position::from);
     }
 
     public static class OrderListConfig {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
@@ -130,13 +130,10 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
         }
 
         var position = this.getWidgetPosition(info);
-        if (position.isEmpty()) {
-            return Optional.empty();
-        }
 
         this.list = new ListWidget(
-            position.get().x(),
-            position.get().y(),
+            position.x(),
+            position.y(),
             175,
             250,
             "Tracked Orders"
@@ -177,14 +174,8 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
         return Optional.of(this.list);
     }
 
-    private Optional<Position> getWidgetPosition(ScreenInfo info) {
-        return Optional.ofNullable(this.configState.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
-            var x = bounds.x() + bounds.width();
-            var y = bounds.y();
-            var padding = 20;
-
-            return new Position(x + padding, y);
-        }));
+    private Position getWidgetPosition(ScreenInfo info) {
+        return Optional.ofNullable(this.configState.position).orElse(new Position(150, 100));
     }
 
     public static class OrderListConfig {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
@@ -13,7 +13,6 @@ import com.github.lutzluca.btrbz.data.OrderModels.TrackedOrder;
 import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.ScreenInfo;
-import com.github.lutzluca.btrbz.utils.Utils;
 import com.github.lutzluca.btrbz.widgets.ListWidget;
 import com.github.lutzluca.btrbz.widgets.base.DraggableWidget;
 import com.github.lutzluca.btrbz.widgets.Renderable;
@@ -149,7 +148,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
             .setMaxVisibleItems(this.configState.maxVisibleChildren)
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for TrackedOrdersListModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
+                this.updateConfig(cfg -> cfg.position = pos);
             });
 
         this.list.onHoverChange((self, oldIdx, newIdx) -> {
@@ -179,7 +178,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info) {
-        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return Optional.ofNullable(this.configState.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             var x = bounds.x() + bounds.width();
             var y = bounds.y();
             var padding = 20;

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
@@ -143,10 +143,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
             .setRemovable(false)
             .setReorderable(false)
             .setMaxVisibleItems(this.configState.maxVisibleChildren)
-            .onDragEnd((self, pos) -> {
-                log.debug("Saving new position for TrackedOrdersListModule: {}", pos);
-                this.updateConfig(cfg -> cfg.position = pos);
-            });
+            .onDragEnd((self, pos) -> this.updateConfig(cfg -> cfg.position = pos));
 
         this.list.onHoverChange((self, oldIdx, newIdx) -> {
             var oldEntry = self.getItem(oldIdx)

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/TrackedOrdersListModule.java
@@ -149,7 +149,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
             .setMaxVisibleItems(this.configState.maxVisibleChildren)
             .onDragEnd((self, pos) -> {
                 log.debug("Saving new position for TrackedOrdersListModule: {}", pos);
-                this.saveConfigPosition(pos, (cfg, x) -> cfg.x = x, (cfg, y) -> cfg.y = y);
+                this.saveConfigPosition(pos, (cfg, savedPosition) -> cfg.position = savedPosition);
             });
 
         this.list.onHoverChange((self, oldIdx, newIdx) -> {
@@ -179,7 +179,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
     }
 
     private Optional<Position> getWidgetPosition(ScreenInfo info) {
-        return this.loadConfigPosition(cfg -> cfg.x, cfg -> cfg.y).or(() -> info.getHandledScreenBounds().map(bounds -> {
+        return this.loadConfigPosition(cfg -> cfg.position).or(() -> info.getHandledScreenBounds().map(bounds -> {
             var x = bounds.x() + bounds.width();
             var y = bounds.y();
             var padding = 20;
@@ -190,7 +190,7 @@ public class TrackedOrdersListModule extends Module<OrderListConfig> {
 
     public static class OrderListConfig {
 
-        public Integer x, y;
+        public Position position;
 
         public boolean enabled = true;
         public boolean showInBazaar = true;

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsConfig.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsConfig.java
@@ -1,5 +1,6 @@
 package com.github.lutzluca.btrbz.core.modules.orderpreset;
 
+import com.github.lutzluca.btrbz.utils.Position;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen;
 import com.github.lutzluca.btrbz.core.config.ConfigScreen.OptionGrouping;
 import dev.isxander.yacl3.api.Option;
@@ -12,8 +13,8 @@ import java.util.List;
 
 public class OrderPresetsConfig {
 
-    public Integer containerX, containerY;
-    public Integer signX, signY;
+    public Position containerPosition;
+    public Position signPosition;
     public boolean enabled = true;
     public boolean enableOnContainer = true;
     public boolean enableOnSign = true;

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -284,7 +284,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
         var position = this.getConfigPosition(screenType).orElseGet(() -> 
             switch (screenType) {
                 case PresetScreen.VolumeSetupContainer -> new Position(570, 180);
-                case PresetScreen.EnterVolumeSign -> new Position(20, 20);
+                case PresetScreen.EnterVolumeSign -> new Position(580, 40);
             }
         );
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -331,24 +331,19 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
         switch (screen) {
             case PresetScreen.VolumeSetupContainer -> this.saveConfigPosition(
                 pos,
-                (cfg, x) -> cfg.containerX = x,
-                (cfg, y) -> cfg.containerY = y
+                (cfg, savedPosition) -> cfg.containerPosition = savedPosition
             );
             case PresetScreen.EnterVolumeSign -> this.saveConfigPosition(
                 pos,
-                (cfg, x) -> cfg.signX = x,
-                (cfg, y) -> cfg.signY = y
+                (cfg, savedPosition) -> cfg.signPosition = savedPosition
             );
         }
     }
 
     private Optional<Position> getConfigPosition(PresetScreen screen) {
         return switch (screen) {
-            case PresetScreen.VolumeSetupContainer -> this.loadConfigPosition(
-                cfg -> cfg.containerX,
-                cfg -> cfg.containerY
-            );
-            case PresetScreen.EnterVolumeSign -> this.loadConfigPosition(cfg -> cfg.signX, cfg -> cfg.signY);
+            case PresetScreen.VolumeSetupContainer -> this.loadConfigPosition(cfg -> cfg.containerPosition);
+            case PresetScreen.EnterVolumeSign -> this.loadConfigPosition(cfg -> cfg.signPosition);
         };
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -269,7 +269,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
         var screen = this.getPresetScreen(info);
         if (screen.isEmpty()) {
             log.warn(
-                "OrderPresetsModule: createWidgets was called but no valid preset screen was found. " +
+                "OrderPresetsModule: createWidget was called but no valid preset screen was found. " +
                     "Current Title: '{}', Current Screen: {}, Previous Title: '{}', In Transaction: {}",
                 info.containerName().orElse("N/A"),
                 info.getScreen() != null ? info.getScreen().getClass().getSimpleName() : "N/A",

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -329,21 +329,15 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
     private void savePosition(Position pos, PresetScreen screen) {
         log.debug("Saving new position for OrderPresetsModule ({}): {}", screen, pos);
         switch (screen) {
-            case PresetScreen.VolumeSetupContainer -> this.saveConfigPosition(
-                pos,
-                (cfg, savedPosition) -> cfg.containerPosition = savedPosition
-            );
-            case PresetScreen.EnterVolumeSign -> this.saveConfigPosition(
-                pos,
-                (cfg, savedPosition) -> cfg.signPosition = savedPosition
-            );
+            case PresetScreen.VolumeSetupContainer -> this.updateConfig(cfg -> cfg.containerPosition = pos);
+            case PresetScreen.EnterVolumeSign -> this.updateConfig(cfg -> cfg.signPosition = pos);
         }
     }
 
     private Optional<Position> getConfigPosition(PresetScreen screen) {
         return switch (screen) {
-            case PresetScreen.VolumeSetupContainer -> this.loadConfigPosition(cfg -> cfg.containerPosition);
-            case PresetScreen.EnterVolumeSign -> this.loadConfigPosition(cfg -> cfg.signPosition);
+            case PresetScreen.VolumeSetupContainer -> Optional.ofNullable(this.configState.containerPosition);
+            case PresetScreen.EnterVolumeSign -> Optional.ofNullable(this.configState.signPosition);
         };
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -327,7 +327,6 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
     }
 
     private void savePosition(Position pos, PresetScreen screen) {
-        log.debug("Saving new position for OrderPresetsModule ({}): {}", screen, pos);
         switch (screen) {
             case PresetScreen.VolumeSetupContainer -> this.updateConfig(cfg -> cfg.containerPosition = pos);
             case PresetScreen.EnterVolumeSign -> this.updateConfig(cfg -> cfg.signPosition = pos);

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/orderpreset/OrderPresetsModule.java
@@ -265,7 +265,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
     }
 
     @Override
-    public List<DraggableWidget> createWidgets(ScreenInfo info) {
+    public Optional<DraggableWidget> createWidget(ScreenInfo info) {
         var screen = this.getPresetScreen(info);
         if (screen.isEmpty()) {
             log.warn(
@@ -277,7 +277,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
                 this.inTransaction
             );
 
-            return List.of();
+            return Optional.empty();
         }
 
         var screenType = screen.get();
@@ -297,7 +297,7 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
             this.list.setX(position.x());
             this.list.setY(position.y());
             this.list.setMaxVisibleItems(maxVisible);
-            return List.of(this.list);
+            return Optional.of(this.list);
         }
 
         this.list = new ListWidget(
@@ -323,31 +323,32 @@ public class OrderPresetsModule extends Module<OrderPresetsConfig> {
 
         this.rebuildList();
 
-        return List.of(this.list);
+        return Optional.of(this.list);
     }
 
     private void savePosition(Position pos, PresetScreen screen) {
         log.debug("Saving new position for OrderPresetsModule ({}): {}", screen, pos);
-        this.updateConfig(cfg -> {
-            switch (screen) {
-                case PresetScreen.VolumeSetupContainer -> {
-                    cfg.containerX = pos.x();
-                    cfg.containerY = pos.y();
-                }
-                case PresetScreen.EnterVolumeSign -> {
-                    cfg.signX = pos.x();
-                    cfg.signY = pos.y();
-                }
-            }
-        });
+        switch (screen) {
+            case PresetScreen.VolumeSetupContainer -> this.saveConfigPosition(
+                pos,
+                (cfg, x) -> cfg.containerX = x,
+                (cfg, y) -> cfg.containerY = y
+            );
+            case PresetScreen.EnterVolumeSign -> this.saveConfigPosition(
+                pos,
+                (cfg, x) -> cfg.signX = x,
+                (cfg, y) -> cfg.signY = y
+            );
+        }
     }
 
     private Optional<Position> getConfigPosition(PresetScreen screen) {
         return switch (screen) {
-            case PresetScreen.VolumeSetupContainer -> Utils.zipNullables(this.configState.containerX, this.configState.containerY)
-                .map(pair -> new Position(pair.getLeft(), pair.getRight()));
-            case PresetScreen.EnterVolumeSign -> Utils.zipNullables(this.configState.signX, this.configState.signY)
-                .map(pair -> new Position(pair.getLeft(), pair.getRight()));
+            case PresetScreen.VolumeSetupContainer -> this.loadConfigPosition(
+                cfg -> cfg.containerX,
+                cfg -> cfg.containerY
+            );
+            case PresetScreen.EnterVolumeSign -> this.loadConfigPosition(cfg -> cfg.signX, cfg -> cfg.signY);
         };
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Position.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Position.java
@@ -1,10 +1,45 @@
 package com.github.lutzluca.btrbz.utils;
 
+import java.lang.reflect.Type;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import org.apache.commons.lang3.tuple.Pair;
 
 public record Position(int x, int y) {
 
     public static Position from(Pair<Integer, Integer> pos) {
         return new Position(pos.getLeft(), pos.getRight());
+    }
+
+    public static class GsonAdapter implements JsonSerializer<Position>, JsonDeserializer<Position> {
+
+        @Override
+        public JsonElement serialize(Position src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject object = new JsonObject();
+            object.addProperty("x", src.x());
+            object.addProperty("y", src.y());
+            return object;
+        }
+
+        @Override
+        public Position deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            if (json == null || json.isJsonNull()) {
+                return null;
+            }
+
+            JsonObject object = json.getAsJsonObject();
+            JsonElement xElement = object.get("x");
+            JsonElement yElement = object.get("y");
+            if (xElement == null || yElement == null || xElement.isJsonNull() || yElement.isJsonNull()) {
+                throw new JsonParseException("Position requires both x and y properties");
+            }
+
+            return new Position(xElement.getAsInt(), yElement.getAsInt());
+        }
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Position.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Position.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
@@ -20,6 +21,10 @@ public record Position(int x, int y) {
 
         @Override
         public JsonElement serialize(Position src, Type typeOfSrc, JsonSerializationContext context) {
+            if (src == null) {
+                return JsonNull.INSTANCE;
+            }
+
             JsonObject object = new JsonObject();
             object.addProperty("x", src.x());
             object.addProperty("y", src.y());

--- a/src/test/java/com/github/lutzluca/btrbz/test/PositionConfigTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/test/PositionConfigTest.java
@@ -2,6 +2,8 @@ package com.github.lutzluca.btrbz.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.github.lutzluca.btrbz.core.modules.OrderBookPriceModule.OrderBookPriceConfig;
 import com.github.lutzluca.btrbz.core.modules.OrderLimitModule.OrderLimitConfig;
 import com.github.lutzluca.btrbz.core.modules.orderpreset.OrderPresetsConfig;
@@ -10,6 +12,7 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -79,6 +82,55 @@ class PositionConfigTest {
             assertEquals(91, json.getAsJsonObject("sign_position").get("y").getAsInt());
             assertFalse(json.has("sign_x"));
             assertFalse(json.has("sign_y"));
+        }
+
+        @Test
+        void serializesNullPosition() {
+            OrderLimitConfig orderLimitConfig = new OrderLimitConfig();
+            orderLimitConfig.position = null;
+
+            JsonObject orderLimitJson = gson.toJsonTree(orderLimitConfig).getAsJsonObject();
+
+            assertFalse(orderLimitJson.has("position"));
+            assertNull(gson.fromJson(orderLimitJson, OrderLimitConfig.class).position);
+
+            OrderBookPriceConfig orderBookPriceConfig = new OrderBookPriceConfig();
+            orderBookPriceConfig.signPosition = null;
+
+            JsonObject orderBookPriceJson = gson.toJsonTree(orderBookPriceConfig).getAsJsonObject();
+
+            assertFalse(orderBookPriceJson.has("sign_position"));
+            assertNull(gson.fromJson(orderBookPriceJson, OrderBookPriceConfig.class).signPosition);
+        }
+
+        @Test
+        void deserializesInvalidPositionThrows() {
+            String missingX = """
+                {
+                  \"position\": { \"y\": 67 },
+                  \"enabled\": true
+                }
+                """;
+
+            String missingY = """
+                {
+                  \"position\": { \"x\": 45 },
+                  \"enabled\": true
+                }
+                """;
+
+            assertThrows(JsonParseException.class, () -> gson.fromJson(missingX, OrderLimitConfig.class));
+            assertThrows(JsonParseException.class, () -> gson.fromJson(missingY, OrderLimitConfig.class));
+        }
+
+        @Test
+        void roundTripPositionSerialization() {
+            OrderPresetsConfig config = new OrderPresetsConfig();
+            config.containerPosition = new Position(21, 43);
+
+            OrderPresetsConfig roundTripped = gson.fromJson(gson.toJson(config), OrderPresetsConfig.class);
+
+            assertEquals(new Position(21, 43), roundTripped.containerPosition);
         }
     }
 }

--- a/src/test/java/com/github/lutzluca/btrbz/test/PositionConfigTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/test/PositionConfigTest.java
@@ -1,0 +1,84 @@
+package com.github.lutzluca.btrbz.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import com.github.lutzluca.btrbz.core.modules.OrderBookPriceModule.OrderBookPriceConfig;
+import com.github.lutzluca.btrbz.core.modules.OrderLimitModule.OrderLimitConfig;
+import com.github.lutzluca.btrbz.core.modules.orderpreset.OrderPresetsConfig;
+import com.github.lutzluca.btrbz.utils.Position;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PositionConfigTest {
+
+    private final Gson gson = new GsonBuilder()
+        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .registerTypeAdapter(Position.class, new Position.GsonAdapter())
+        .create();
+
+    @Nested
+    @DisplayName("Position Serialization")
+    class PositionSerialization {
+
+        @Test
+        void serializesConfigPositionAsNestedObject() {
+            OrderLimitConfig config = new OrderLimitConfig();
+            config.position = new Position(12, 34);
+
+            JsonObject json = gson.toJsonTree(config).getAsJsonObject();
+
+            assertEquals(12, json.getAsJsonObject("position").get("x").getAsInt());
+            assertEquals(34, json.getAsJsonObject("position").get("y").getAsInt());
+            assertFalse(json.has("x"));
+            assertFalse(json.has("y"));
+        }
+
+        @Test
+        void deserializesNestedPositionObject() {
+            String json = """
+                {
+                  \"position\": { \"x\": 45, \"y\": 67 },
+                  \"enabled\": true
+                }
+                """;
+
+            OrderLimitConfig config = gson.fromJson(json, OrderLimitConfig.class);
+
+            assertEquals(new Position(45, 67), config.position);
+        }
+
+        @Test
+        void deserializesNamedPositionObjects() {
+            String json = """
+                {
+                  \"container_position\": { \"x\": 11, \"y\": 22 },
+                  \"sign_position\": { \"x\": 33, \"y\": 44 },
+                  \"enabled\": true
+                }
+                """;
+
+            OrderPresetsConfig config = gson.fromJson(json, OrderPresetsConfig.class);
+
+            assertEquals(new Position(11, 22), config.containerPosition);
+            assertEquals(new Position(33, 44), config.signPosition);
+        }
+
+        @Test
+        void usesNamedPositionFieldForSignOverlay() {
+            OrderBookPriceConfig config = new OrderBookPriceConfig();
+            config.signPosition = new Position(90, 91);
+
+            JsonObject json = gson.toJsonTree(config).getAsJsonObject();
+
+            assertEquals(90, json.getAsJsonObject("sign_position").get("x").getAsInt());
+            assertEquals(91, json.getAsJsonObject("sign_position").get("y").getAsInt());
+            assertFalse(json.has("sign_x"));
+            assertFalse(json.has("sign_y"));
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Widget position config restructured to use nested Position objects; previously saved positions are reset to defaults (no migration).

* **Behavior Changes**
  * Modules now produce at most one draggable widget (or none), changing overlay presence and some default/fallback coordinates.
  * Drag-end persistence now writes unified position objects.

* **New Features**
  * Position objects serialize/deserialize as nested JSON objects with strict x/y validation.

* **Tests**
  * Added tests for Position JSON serialization, deserialization, null-handling and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->