### PR TITLE
hot-fix: fix mod incompatibility with skyblock-api 4.1.11+ 

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/utils/ItemOverrideManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/ItemOverrideManager.java
@@ -14,33 +14,43 @@ public class ItemOverrideManager {
 
     private static final List<ItemOverrideRule> RULES = new ArrayList<>();
 
+    private static final ThreadLocal<Boolean> APPLYING = ThreadLocal.withInitial(() -> false);
 
     public static void register(ItemOverrideRule rule) {
         RULES.add(rule);
     }
 
     public static ItemStack apply(ScreenInfo info, Slot slot, ItemStack original) {
-        for (ItemOverrideRule rule : RULES) {
-            var replacement = Try.of(() -> rule.replace(info, slot, original))
-                .onFailure(err -> log.error(
-                    "Item override rule '{}' failed for screen '{}' and slot '{}'",
-                    rule.getClass().getName(),
-                    info.containerName().orElse("<unknown>"),
-                    slot == null ? "<null>" : slot.getContainerSlot(),
-                    err
-                ))
-                .getOrElse(Optional.empty());
-
-            if (replacement.isPresent()) {
-                return replacement.get();
-            }
+        if (APPLYING.get()) {
+            return original;
         }
 
-        return original;
+        try {
+            APPLYING.set(true);
+
+            for (ItemOverrideRule rule : RULES) {
+                var replacement = Try.of(() -> rule.replace(info, slot, original))
+                    .onFailure(err -> log.error(
+                        "Item override rule '{}' failed for screen '{}' and slot '{}'",
+                        rule.getClass().getName(),
+                        info.containerName().orElse("<unknown>"),
+                        slot == null ? "<null>" : slot.getContainerSlot(),
+                        err
+                    ))
+                    .getOrElse(Optional.empty());
+
+                if (replacement.isPresent()) {
+                    return replacement.get();
+                }
+            }
+
+            return original;
+        } finally {
+            APPLYING.set(false);
+        }
     }
 
     public interface ItemOverrideRule {
-
         Optional<ItemStack> replace(ScreenInfo info, Slot slot, ItemStack original);
     }
 }


### PR DESCRIPTION
Added a recursive check to prevent crashes with skyblock-api 4.1.11+

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a recursion issue where item override rules could trigger themselves repeatedly on the same thread, potentially causing unintended behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LutzLuca/BtrBz/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->