### PR TITLE
refactor: performance improvments

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
+++ b/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
@@ -149,8 +149,8 @@ public class BtrBz implements ClientModInitializer {
             orderActions.setReopenBazaar();
         });
 
-        BAZAAR_DATA.addListener(this.alertManager::onBazaarUpdate);
-        BAZAAR_DATA.addListener(this.orderManager::onBazaarUpdate);
+        BAZAAR_DATA.addBazaarListener(this.alertManager::onBazaarUpdate);
+        BAZAAR_DATA.addBazaarListener(this.orderManager::onBazaarUpdate);
 
         new BazaarPoller(BAZAAR_DATA::onUpdate);
         var flipHelper = new FlipHelper(BAZAAR_DATA);

--- a/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
+++ b/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
@@ -152,7 +152,7 @@ public class BtrBz implements ClientModInitializer {
         BAZAAR_DATA.addBazaarListener(this.alertManager::onBazaarUpdate);
         BAZAAR_DATA.addBazaarListener(this.orderManager::onBazaarUpdate);
 
-        new BazaarPoller(BAZAAR_DATA::onUpdate);
+        new BazaarPoller(BAZAAR_DATA::notifyBazaarListeners);
         var flipHelper = new FlipHelper(BAZAAR_DATA);
 
         MESSAGE_DISPATCHER.on(BazaarMessage.OrderFlipped.class, flipHelper::handleFlipped);

--- a/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/OrderTooltipProvider.java
@@ -62,7 +62,7 @@ public class OrderTooltipProvider {
         this.listCache = new OrderTooltipCache("list");
         this.itemCache = new OrderTooltipCache("item");
 
-        this.bazaarData.addListener(products -> {
+        this.bazaarData.addBazaarListener(products -> {
             this.listCache.clear();
             this.itemCache.clear();
         });

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.WeakHashMap;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.fabricmc.fabric.api.client.item.v1.ItemTooltipCallback;
@@ -539,8 +538,9 @@ public final class ProductInfoProvider {
         }
 
         Optional<String> get(ItemStack stack) {
-            if (cache.containsKey(stack)) {
-                return cache.get(stack);
+            var cached = cache.get(stack);
+            if (cached != null) {
+                return cached;
             }
 
             var name = stack.getHoverName().getString();
@@ -596,9 +596,11 @@ public final class ProductInfoProvider {
         }
 
         Optional<CachedPrice> get(ItemStack stack) {
-            if (cache.containsKey(stack)) {
-                return Optional.ofNullable(cache.get(stack));
+            var existing = cache.get(stack);
+            if (existing != null || cache.containsKey(stack)) {
+                return Optional.ofNullable(existing);
             }
+
             var productId = ProductInfoProvider.this.productIdCache.get(stack);
 
             if (productId.isEmpty()) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -550,7 +550,7 @@ public final class ProductInfoProvider {
         }
 
         Optional<String> get(ItemStack stack) {
-            var cached = cache.get(stack);
+            var cached = this.cache.get(stack);
             if (cached != null) {
                 return cached;
             }
@@ -559,7 +559,7 @@ public final class ProductInfoProvider {
 
             var direct = ProductInfoProvider.this.bazaarData.nameToId(name);
             if (direct.isPresent()) {
-                cache.put(stack, direct);
+                this.cache.put(stack, direct);
                 return direct;
             }
 
@@ -574,19 +574,19 @@ public final class ProductInfoProvider {
 
                 var result = ids.size() == 1 ? Optional.of(ids.getFirst()) : Optional.<String>empty();
 
-                cache.put(stack, result);
+                this.cache.put(stack, result);
                 return result;
             }
 
             var delimiter = name.lastIndexOf(' ');
             if (delimiter == -1 || !Utils.isValidRomanNumeral(name.substring(delimiter).trim())) {
-                cache.put(stack, Optional.empty());
+                this.cache.put(stack, Optional.empty());
                 return Optional.empty();
             }
 
             var result = ProductInfoProvider.this.bazaarData.nameToId(name.substring(0, delimiter).trim());
 
-            cache.put(stack, result);
+            this.cache.put(stack, result);
             return result;
         }
     }
@@ -603,20 +603,20 @@ public final class ProductInfoProvider {
                     this.cache.size()
                 );
 
-                cache.clear();
+                this.cache.clear();
             });
         }
 
         Optional<CachedPrice> get(ItemStack stack) {
-            var existing = cache.get(stack);
-            if (existing != null || cache.containsKey(stack)) {
+            var existing = this.cache.get(stack);
+            if (existing != null || this.cache.containsKey(stack)) {
                 return Optional.ofNullable(existing);
             }
 
             var productId = ProductInfoProvider.this.productIdCache.get(stack);
 
             if (productId.isEmpty()) {
-                cache.put(stack, null);
+                this.cache.put(stack, null);
                 return Optional.empty();
             }
 
@@ -626,7 +626,7 @@ public final class ProductInfoProvider {
             var buyOrderPrice = data.highestBuyPrice(productId.get()).orElse(null);
 
             var cached = new CachedPrice(sellOfferPrice, buyOrderPrice);
-            cache.put(stack, cached);
+            this.cache.put(stack, cached);
 
             log.trace(
                 "Cached price for '{}' (id: {}): buy={}, sell={}",

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -173,8 +173,8 @@ public final class ProductInfoProvider {
     private ItemStack createProductInfoItem() {
         var cfg = ConfigManager.get().productInfo;
 
-        if (cachedProductInfoItem != null && cachedProductInfoSite == cfg.site) {
-            return cachedProductInfoItem;
+        if (this.cachedProductInfoItem != null && this.cachedProductInfoSite == cfg.site) {
+            return this.cachedProductInfoItem.copy();
         }
 
         var item = new ItemStack(Items.PAPER);
@@ -201,9 +201,9 @@ public final class ProductInfoProvider {
 
         item.set(DataComponents.LORE, new ItemLore(loreLines));
 
-        cachedProductInfoItem = item;
-        cachedProductInfoSite = cfg.site;
-        return cachedProductInfoItem.copy();
+        this.cachedProductInfoItem = item;
+        this.cachedProductInfoSite = cfg.site;
+        return this.cachedProductInfoItem.copy();
     }
 
     private void registerTooltipDisplay() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -539,9 +539,9 @@ public final class ProductInfoProvider {
 
         ProductIdCache() {
             log.debug("Initializing Product ID Cache");
-            ProductInfoProvider.this.bazaarData.addListener(products -> {
+            ProductInfoProvider.this.bazaarData.addConversionListener(() -> {
                 log.trace(
-                    "Bazaar data updated, clearing product id cache with {} mappings",
+                    "Conversions updated, clearing product id cache with {} mappings",
                     this.cache.size()
                 );
 
@@ -597,7 +597,7 @@ public final class ProductInfoProvider {
 
         PriceCache() {
             log.debug("Initializing Price Cache");
-            ProductInfoProvider.this.bazaarData.addListener(products -> {
+            ProductInfoProvider.this.bazaarData.addBazaarListener(products -> {
                 log.trace(
                     "Bazaar data updated, clearing price cache with {} mappings",
                     this.cache.size()

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -281,19 +281,20 @@ public final class ProductInfoProvider {
             return false;
         }
 
+        boolean inBazaarMainOrItem = ScreenInfoHelper.inMenu(BazaarMenuType.Main, BazaarMenuType.Item);
+        if (!inBazaarMainOrItem && !cfg.showOutsideBazaar && !ScreenInfoHelper.inBazaar()) {
+            return false;
+        }
+
         if (this.productIdCache.get(stack).isEmpty()) {
             return false;
         }
 
-        if (ScreenInfoHelper.inMenu(BazaarMenuType.Main, BazaarMenuType.Item)) {
+        if (inBazaarMainOrItem) {
             return this.isStackInPlayerInventory(stack);
         }
 
-        if (cfg.showOutsideBazaar) {
-            return true;
-        }
-
-        return ScreenInfoHelper.inBazaar();
+        return true;
     }
 
     private boolean isStackInPlayerInventory(ItemStack stack) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -66,6 +66,9 @@ public final class ProductInfoProvider {
     private final PriceCache priceCache;
     private final ProductIdCache productIdCache;
 
+    private @Nullable ItemStack cachedProductInfoItem = null;
+    private @Nullable InfoProviderSite cachedProductInfoSite = null;
+
     @Getter
     private @Nullable ProductNameInfo openedProductNameInfo;
 
@@ -169,6 +172,11 @@ public final class ProductInfoProvider {
 
     private ItemStack createProductInfoItem() {
         var cfg = ConfigManager.get().productInfo;
+
+        if (cachedProductInfoItem != null && cachedProductInfoSite == cfg.site) {
+            return cachedProductInfoItem;
+        }
+
         var item = new ItemStack(Items.PAPER);
         item.set(
             DataComponents.CUSTOM_NAME,
@@ -192,7 +200,10 @@ public final class ProductInfoProvider {
         ).<Component>map(line -> line.withStyle(style -> style.withItalic(false))).toList();
 
         item.set(DataComponents.LORE, new ItemLore(loreLines));
-        return item;
+
+        cachedProductInfoItem = item;
+        cachedProductInfoSite = cfg.site;
+        return cachedProductInfoItem.copy();
     }
 
     private void registerTooltipDisplay() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -65,12 +65,15 @@ public final class ProductInfoProvider {
 
     private final BazaarData bazaarData;
     private final PriceCache priceCache;
+    private final ProductIdCache productIdCache;
+
     @Getter
     private @Nullable ProductNameInfo openedProductNameInfo;
 
     public ProductInfoProvider(BazaarData bazaarData) {
         this.bazaarData = bazaarData;
         this.priceCache = new PriceCache();
+        this.productIdCache = new ProductIdCache();
         this.registerProductInfoListener();
         this.registerSlotHooks();
         this.registerTooltipDisplay();
@@ -268,8 +271,7 @@ public final class ProductInfoProvider {
             return false;
         }
 
-        var productName = stack.getHoverName().getString();
-        if (this.resolveProductId(stack, productName).isEmpty()) {
+        if (this.productIdCache.get(stack).isEmpty()) {
             return false;
         }
 
@@ -313,32 +315,6 @@ public final class ProductInfoProvider {
                 client.setScreen(prev != null ? prev.getScreen() : null);
             }, link, true
         ));
-    }
-
-    private Optional<String> resolveProductId(ItemStack stack, String name) {
-        var direct = this.bazaarData.nameToId(name);
-        if (direct.isPresent()) {
-            return direct;
-        }
-
-        if ("Enchanted Book".equals(name)) {
-            var ids = OrderInfoParser
-                .getLore(stack)
-                .stream()
-                .map(this.bazaarData::nameToId)
-                .flatMap(Optional::stream)
-                .distinct()
-                .toList();
-
-            return ids.size() == 1 ? Optional.of(ids.getFirst()) : Optional.empty();
-        }
-
-        var delimiter = name.lastIndexOf(' ');
-        if (delimiter == -1 || !Utils.isValidRomanNumeral(name.substring(delimiter).trim())) {
-            return Optional.empty();
-        }
-
-        return this.bazaarData.nameToId(name.substring(0, delimiter).trim());
     }
 
     public enum InfoProviderSite {
@@ -429,10 +405,9 @@ public final class ProductInfoProvider {
 
             var cfg = ConfigManager.get().productInfo;
             var stack = ctx.view().rawStack();
-            var name = stack.getHoverName().getString();
-            var id = ProductInfoProvider.this.resolveProductId(stack, name);
+            var id = ProductInfoProvider.this.productIdCache.get(stack);
             if (id.isEmpty()) {
-                log.warn("No product id found for {}", name);
+                log.warn("No product id found for {}", stack.getHoverName().getString());
                 return SlotClickResult.Pass;
             }
 
@@ -540,6 +515,63 @@ public final class ProductInfoProvider {
         }
     }
 
+    private class ProductIdCache {
+
+        private final WeakHashMap<ItemStack, Optional<String>> cache = new WeakHashMap<>();
+
+        ProductIdCache() {
+            log.debug("Initializing Product ID Cache");
+            ProductInfoProvider.this.bazaarData.addListener(products -> {
+                log.trace(
+                    "Bazaar data updated, clearing product id cache with {} mappings",
+                    this.cache.size()
+                );
+
+                this.cache.clear();
+            });
+        }
+
+        Optional<String> get(ItemStack stack) {
+            if (cache.containsKey(stack)) {
+                return cache.get(stack);
+            }
+
+            var name = stack.getHoverName().getString();
+
+            var direct = ProductInfoProvider.this.bazaarData.nameToId(name);
+            if (direct.isPresent()) {
+                cache.put(stack, direct);
+                return direct;
+            }
+
+            if ("Enchanted Book".equals(name)) {
+                var ids = OrderInfoParser
+                    .getLore(stack)
+                    .stream()
+                    .map(ProductInfoProvider.this.bazaarData::nameToId)
+                    .flatMap(Optional::stream)
+                    .distinct()
+                    .toList();
+
+                var result = ids.size() == 1 ? Optional.of(ids.getFirst()) : Optional.<String>empty();
+
+                cache.put(stack, result);
+                return result;
+            }
+
+            var delimiter = name.lastIndexOf(' ');
+            if (delimiter == -1 || !Utils.isValidRomanNumeral(name.substring(delimiter).trim())) {
+                cache.put(stack, Optional.empty());
+                return Optional.empty();
+            }
+
+            var result = ProductInfoProvider.this.bazaarData.nameToId(name.substring(0, delimiter).trim());
+
+            cache.put(stack, result);
+            return result;
+        }
+    }
+
     private class PriceCache {
 
         private final WeakHashMap<ItemStack, @Nullable CachedPrice> cache = new WeakHashMap<>();
@@ -560,8 +592,7 @@ public final class ProductInfoProvider {
             if (cache.containsKey(stack)) {
                 return Optional.ofNullable(cache.get(stack));
             }
-            var name = stack.getHoverName().getString();
-            var productId = resolveProductId(stack, name);
+            var productId = ProductInfoProvider.this.productIdCache.get(stack);
 
             if (productId.isEmpty()) {
                 cache.put(stack, null);
@@ -578,7 +609,7 @@ public final class ProductInfoProvider {
 
             log.trace(
                 "Cached price for '{}' (id: {}): buy={}, sell={}",
-                name,
+                stack.getHoverName().getString(),
                 productId.get(),
                 buyOrderPrice,
                 sellOfferPrice

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -289,11 +289,18 @@ public final class ProductInfoProvider {
     private boolean isStackInPlayerInventory(ItemStack stack) {
         // NOTE: reference equality is intentional here
         // noinspection DataFlowIssue
-        return Try
-            .of(() -> StreamSupport
-                .stream(Minecraft.getInstance().player.getInventory().spliterator(), false)
-                .anyMatch(playerStack -> playerStack == stack))
-            .getOrElse(false);
+        var player = Minecraft.getInstance().player;
+        if (player == null) {
+            return false;
+        }
+
+        for (var playerStack : player.getInventory()) {
+            if (playerStack == stack) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void confirmAndOpen(String link) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/BookmarkModule.java
@@ -272,7 +272,6 @@ public class BookmarkModule extends Module<BookMarkConfig> {
             this.orderBuySet = orderBuySet;
             this.orderSellSet = orderSellSet;
 
-            //noinspection DataFlowIssue
             this.color = (0xFF << 24) | Try
                 .of(() -> itemStack.getHoverName().getSiblings().getFirst()
                     .getStyle().getColor().getValue())

--- a/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/modules/OrderBookPriceModule.java
@@ -61,7 +61,7 @@ public class OrderBookPriceModule extends Module<OrderBookPriceModule.OrderBookP
             }
         });
 
-        this.context().bazaarData().addListener(products -> {
+        this.context().bazaarData().addBazaarListener(products -> {
             var productNameInfo = this.context().productInfoProvider().getOpenedProductNameInfo();
             if (this.isDisplayed() && productNameInfo != null) {
                 this.rebuildList();

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -54,8 +54,8 @@ public class OrderBookScreenController {
 
         @Override
         public ItemStack createDisplayStack(SlotRenderContext ctx) {
-            if (cachedDisplayStack != null) {
-                return cachedDisplayStack;
+            if (this.cachedDisplayStack != null) {
+                return this.cachedDisplayStack.copy();
             }
 
             var book = new ItemStack(Items.BOOK);
@@ -64,8 +64,8 @@ public class OrderBookScreenController {
                 Component.literal("Open Order Book").withStyle(style -> style.withItalic(false))
             );
 
-            cachedDisplayStack = book;
-            return cachedDisplayStack.copy();
+            this.cachedDisplayStack = book;
+            return this.cachedDisplayStack.copy();
         }
 
         @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -20,6 +20,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
+import org.jetbrains.annotations.Nullable;
 
 public class OrderBookScreenController {
 
@@ -34,8 +35,10 @@ public class OrderBookScreenController {
     }
 
     public final class OrderBookButtonHook implements SlotHook {
+        private @Nullable ItemStack cachedDisplayStack = null;
 
         private OrderBookButtonHook() { }
+
         @Override
         public boolean matches(SlotView view) {
             return ConfigManager.get().orderBook.enabled
@@ -51,13 +54,18 @@ public class OrderBookScreenController {
 
         @Override
         public ItemStack createDisplayStack(SlotRenderContext ctx) {
+            if (cachedDisplayStack != null) {
+                return cachedDisplayStack;
+            }
+
             var book = new ItemStack(Items.BOOK);
             book.set(
                 DataComponents.CUSTOM_NAME,
                 Component.literal("Open Order Book").withStyle(style -> style.withItalic(false))
             );
 
-            return book;
+            cachedDisplayStack = book;
+            return cachedDisplayStack.copy();
         }
 
         @Override

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -18,12 +18,14 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product;
 import net.hypixel.api.reply.skyblock.SkyBlockBazaarReply.Product.Summary;
+import net.minecraft.client.Minecraft;
 import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public class BazaarData {
 
-    private final List<Consumer<Map<String, Product>>> listeners = new ArrayList<>();
+    private final List<Consumer<Map<String, Product>>> bazaarListeners = new ArrayList<>();
+    private final List<Runnable> conversionListeners = new ArrayList<>();
     private Map<String, Product> lastProducts = Collections.emptyMap();
     private volatile BiMap<String, String> idToName;
 
@@ -45,7 +47,10 @@ public class BazaarData {
         ConversionLoader.load().thenAccept(result ->
             result
                 .onSuccess(loadResult -> {
-                    this.idToName = loadResult.conversions();
+                    Minecraft.getInstance().execute(() -> {
+                        this.idToName = loadResult.conversions();
+                        this.conversionListeners.forEach(Runnable::run);
+                    });
                     log.debug("Conversions applied ({} entries)", loadResult.conversions().size());
 
                     ConversionLoader.checkForConversionUpdates(loadResult.contentHash())
@@ -53,7 +58,10 @@ public class BazaarData {
                             updateResult
                                 .onSuccess(maybeNew ->
                                     maybeNew.ifPresent(newResult -> {
-                                        this.idToName = newResult.conversions();
+                                        Minecraft.getInstance().execute(() -> {
+                                            this.idToName = newResult.conversions();
+                                            this.conversionListeners.forEach(Runnable::run);
+                                        });
                                         log.debug("Updated conversions applied ({} entries)", newResult.conversions().size());
                                     })
                                 )
@@ -77,29 +85,46 @@ public class BazaarData {
         this.lastProducts = products;
         var snapshotProducts = Collections.unmodifiableMap(this.lastProducts);
 
-        for (var listener : this.listeners) {
-            Try.run(() -> listener.accept(snapshotProducts)).onFailure(err -> log.error(
+        for (var bazaarListener : this.bazaarListeners) {
+            Try.run(() -> bazaarListener.accept(snapshotProducts)).onFailure(err -> log.error(
                 "Bazaar update listener '{}' failed while processing {} products",
-                listener.getClass().getName(),
+                bazaarListener.getClass().getName(),
                 snapshotProducts.size(),
                 err
             ));
         }
     }
 
-    public void addListener(Consumer<Map<String, Product>> listener) {
-        this.listeners.add(listener);
+    public void addConversionListener(Runnable listener) {
+        this.conversionListeners.add(listener);
         log.trace(
-            "Inserting listener for onBazaarUpdate currently, listeners registered: {}",
-            this.listeners.size()
+            "Inserting listener for onConversionUpdate currently, bazaarListeners registered: {}",
+            this.conversionListeners.size()
         );
     }
 
-    public void removeListener(Consumer<Map<String, Product>> listener) {
-        if (this.listeners.remove(listener)) {
+    public void removeConversionListener(Runnable listener) {
+        if (this.conversionListeners.remove(listener)) {
             log.trace(
-                "Removing listener for onBazaarUpdate currently, listeners registered: {}",
-                this.listeners.size()
+                "Removing listener for onConversionUpdate currently, bazaarListeners registered: {}",
+                this.conversionListeners.size()
+            );
+        }
+    }
+
+    public void addBazaarListener(Consumer<Map<String, Product>> listener) {
+        this.bazaarListeners.add(listener);
+        log.trace(
+            "Inserting listener for onBazaarUpdate currently, bazaarListeners registered: {}",
+            this.bazaarListeners.size()
+        );
+    }
+
+    public void removeBazaarListener(Consumer<Map<String, Product>> listener) {
+        if (this.bazaarListeners.remove(listener)) {
+            log.trace(
+                "Removing listener for onBazaarUpdate currently, bazaarListeners registered: {}",
+                this.bazaarListeners.size()
             );
         }
     }
@@ -278,7 +303,7 @@ public class BazaarData {
                 .ifPresent(prod -> {
                     this.product = Optional.of(prod);
 
-                    this.data.addListener(this.updater);
+                    this.data.addBazaarListener(this.updater);
                     this.listenerRegistered = true;
                 });
         }
@@ -301,7 +326,7 @@ public class BazaarData {
 
         public void destroy() {
             this.product = Optional.empty();
-            this.data.removeListener(this.updater);
+            this.data.removeBazaarListener(this.updater);
         }
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -49,7 +49,7 @@ public class BazaarData {
                 .onSuccess(loadResult -> {
                     Minecraft.getInstance().execute(() -> {
                         this.idToName = loadResult.conversions();
-                        this.conversionListeners.forEach(Runnable::run);
+                        this.notifyConversionListeners();
                     });
                     log.debug("Conversions applied ({} entries)", loadResult.conversions().size());
 
@@ -60,7 +60,7 @@ public class BazaarData {
                                     maybeNew.ifPresent(newResult -> {
                                         Minecraft.getInstance().execute(() -> {
                                             this.idToName = newResult.conversions();
-                                            this.conversionListeners.forEach(Runnable::run);
+                                            this.notifyConversionListeners();
                                         });
                                         log.debug("Updated conversions applied ({} entries)", newResult.conversions().size());
                                     })
@@ -81,15 +81,11 @@ public class BazaarData {
         );
     }
 
-    public void onUpdate(Map<String, Product> products) {
-        this.lastProducts = products;
-        var snapshotProducts = Collections.unmodifiableMap(this.lastProducts);
-
-        for (var bazaarListener : this.bazaarListeners) {
-            Try.run(() -> bazaarListener.accept(snapshotProducts)).onFailure(err -> log.error(
-                "Bazaar update listener '{}' failed while processing {} products",
-                bazaarListener.getClass().getName(),
-                snapshotProducts.size(),
+    private void notifyConversionListeners() {
+        for (var listener : this.conversionListeners) {
+            Try.run(listener::run).onFailure(err -> log.error(
+                "Conversion update listener '{}' failed",
+                listener.getClass().getName(),
                 err
             ));
         }
@@ -109,6 +105,20 @@ public class BazaarData {
                 "Removing listener for onConversionUpdate currently, bazaarListeners registered: {}",
                 this.conversionListeners.size()
             );
+        }
+    }
+
+    public void notifyBazaarListeners(Map<String, Product> products) {
+        this.lastProducts = products;
+        var snapshotProducts = Collections.unmodifiableMap(this.lastProducts);
+
+        for (var bazaarListener : this.bazaarListeners) {
+            Try.run(() -> bazaarListener.accept(snapshotProducts)).onFailure(err -> log.error(
+                "Bazaar update listener '{}' failed while processing {} products",
+                bazaarListener.getClass().getName(),
+                snapshotProducts.size(),
+                err
+            ));
         }
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
@@ -36,7 +36,14 @@ public abstract class SlotItemProjectionMixin {
     @Unique
     private boolean btrbz$isCurrentMenuSlot(Slot slot) {
         var screen = Minecraft.getInstance().screen;
-        return screen instanceof AbstractContainerScreen<?> containerScreen
-            && containerScreen.getMenu().slots.contains(slot);
+
+        if (!(screen instanceof AbstractContainerScreen<?> containerScreen)) {
+            return false;
+        }
+
+        var slots = containerScreen.getMenu().slots;
+        int idx = slot.index;
+
+        return idx < slots.size() && slots.get(idx) == slot;
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
@@ -16,7 +16,7 @@ public abstract class SlotItemProjectionMixin {
 
     @Inject(method = "getItem", at = @At("RETURN"), cancellable = true)
     private void projectItem(CallbackInfoReturnable<ItemStack> cir) {
-        if (VirtualSlotProjection.isProjectionSuppressed()) {
+        if (!Minecraft.getInstance().isSameThread()) {
             return;
         }
 

--- a/src/main/java/com/github/lutzluca/btrbz/utils/ScreenInfoHelper.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/ScreenInfoHelper.java
@@ -285,7 +285,12 @@ public final class ScreenInfoHelper {
         }
 
         public boolean inMenu(BazaarMenuType... menu) {
-            return Arrays.stream(menu).anyMatch((menuType) -> this.state.matches(this, menuType));
+            for (var type : menu) {
+                if (this.state.matches(this, type)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public Optional<BazaarMenuType> getMenuType() {

--- a/src/main/java/com/github/lutzluca/btrbz/utils/slot/VirtualSlotProjection.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/slot/VirtualSlotProjection.java
@@ -16,10 +16,6 @@ public final class VirtualSlotProjection {
 
     private VirtualSlotProjection() { }
 
-    public static boolean isProjectionSuppressed() {
-        return SUPPRESSION_DEPTH.get() > 0;
-    }
-
     public static <T> T withProjectionSuppressed(Supplier<T> supplier) {
         int prevDepth = SUPPRESSION_DEPTH.get();
         SUPPRESSION_DEPTH.set(prevDepth + 1);
@@ -27,16 +23,12 @@ public final class VirtualSlotProjection {
         try {
             return supplier.get();
         } finally {
-            if (prevDepth == 0) {
-                SUPPRESSION_DEPTH.remove();
-            } else {
-                SUPPRESSION_DEPTH.set(prevDepth);
-            }
+            SUPPRESSION_DEPTH.set(prevDepth);
         }
     }
 
     public static ItemStack project(Slot slot, ItemStack raw) {
-        if (VirtualSlotProjection.isProjectionSuppressed()) {
+        if (SUPPRESSION_DEPTH.get() > 0) {
             return raw;
         }
 


### PR DESCRIPTION
Profiling pass on the render thread. got it from ~5.68% down to ~2.02% time on thread

**hot path stuff**
- btrbz$isCurrentMenuSlot was doing List.contains() on every slot render, swapped to slots.get(slot.index) == slot
- replaced streams/anyMatch with plain for loops in a few places streams have too much overhead in java
- single get() + null check instead of containsKey + get in the map lookups
- cache ItemStack.getItem() in order book and product info hooks
- moved the screen context check before the cache lookup in shouldApplyShiftClick so the cheap check gets checked first
- added ProductIdCache so hooks aren't all doing redundant id lookups
- deleted SUPPRESSION_DEPTH.remove() in favour of SUPPRESSION_DEPTH.set()

**threading fix**
- fixed rare render freeze when swapping menus quickly caused by skyblockAPI calling project() from the netty thread by adding isSameThread() guard in the mixin instead of relying on the SUPPRESSION_DEPTH.

**other**
- added a listener only for conversion changes on bazaar data
- renamed old "listener" to bazaarListeners as to not confuse with conversionListeners






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, more consistent Bazaar tooltip recognition with improved click-to-open behavior.
  * “Open Order Book” now reuses a cached display item for smoother UI interaction.

* **Bug Fixes**
  * Bazaar and conversion refreshes now update tooltips and the order book more reliably.
  * CTRL+SHIFT and external-site shortcuts behave more consistently in Bazaar menus and outside them.
  * Improved stability for slot/item projection rendering when not on the main game thread.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->