### PR TITLE
port: add support for 26.2

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ stonecutter {
     centralScript = "build.gradle.kts"
 
     create(rootProject) {
-        versions("26.1")
+        versions("26.1","26.2")
         vcsVersion = "26.1"
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -353,7 +353,12 @@ public final class ProductInfoProvider {
     }
 
     private void confirmAndOpen(String link) {
+        //? if <26.2 {
         var client = Minecraft.getInstance();
+        //?} else {
+        /*var client = Minecraft.getInstance().gui;
+         *///?}
+
         client.setScreen(new ConfirmLinkScreen(
             confirmed -> {
                 if (confirmed) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class ConfigScreen {
 
+    //? if <26.2 {
     public static void open() {
         var client = Minecraft.getInstance();
         client.schedule(() -> client.setScreen(ConfigScreen.create(
@@ -26,6 +27,15 @@ public class ConfigScreen {
             ConfigManager.get()
         )));
     }
+    //?} else {
+    /*public static void open() {
+        var client = Minecraft.getInstance();
+        client.schedule(() -> client.gui.setScreen(ConfigScreen.create(
+            client.gui.screen(),
+            ConfigManager.get()
+        )));
+    }
+    *///?}
 
     public static Screen create(Screen parent, Config config) {
         return YetAnotherConfigLib.create(

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
@@ -120,7 +120,11 @@ public class OrderBookScreen extends Screen {
 
     @Override
     public void onClose() {
+        //? if <26.2 {
         Minecraft.getInstance().setScreen(parent);
+        //?} else {
+        /*Minecraft.getInstance().gui.setScreen(parent);
+         *///?}
     }
 
     @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -89,7 +89,11 @@ public class OrderBookScreenController {
                 title,
                 orders
             );
+            //? if <26.2 {
             Minecraft.getInstance().setScreen(orderBookScreen);
+            //?} else {
+            /*Minecraft.getInstance().gui.setScreen(orderBookScreen);
+             *///?}
             return SlotClickResult.Consume;
         }
     }

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/MinecraftClientMixin.java
@@ -8,8 +8,17 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+//? if <26.2 {
+import net.minecraft.client.Minecraft;
+//?} else {
+/*import net.minecraft.client.gui.Gui;
+ *///?}
 
+//? if <26.2 {
 @Mixin(Minecraft.class)
+//?} else {
+/*@Mixin(Gui.class)
+ *///?}
 public abstract class MinecraftClientMixin {
     // @formatter:off
     /**

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
@@ -42,7 +42,11 @@ public abstract class SlotItemProjectionMixin {
 
     @Unique
     private boolean btrbz$isCurrentMenuSlot(Slot slot) {
+        //? if <26.2 {
         var screen = Minecraft.getInstance().screen;
+        //?} else {
+        /*var screen = Minecraft.getInstance().gui.screen();
+        *///?}
 
         if (!(screen instanceof AbstractContainerScreen<?> containerScreen)) {
             return false;

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -38,7 +38,11 @@ public final class GameUtils {
         var accessor = (com.github.lutzluca.btrbz.mixin.AbstractSignEditScreenAccessor) signEditScreen;
         accessor.setLine(0);
         accessor.invokeSetMessage(value);
+        //? if <26.2 {
         Minecraft.getInstance().setScreen(null);
+        //?} else {
+        /*Minecraft.getInstance().gui.setScreen(null);
+         *///?}
     }
 
     public static final int GLOBAL_MAX_ORDER_VOLUME = 71680;

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
@@ -29,6 +29,7 @@ import net.minecraft.world.item.ItemStack;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import static java.util.Locale.ROOT;
 
 public final class Utils {
 
@@ -186,10 +187,22 @@ public final class Utils {
     private static void appendLegacyStyle(StringBuilder out, Style style) {
         TextColor color = style.getColor();
         if (color != null) {
+            //? if <26.2 {
             var formatting = ChatFormatting.getByName(color.serialize());
             if (formatting != null && formatting.isColor()) {
                 out.append(formatting);
             }
+            //?} else {
+            /*String serialized = color.serialize();
+            if (serialized.startsWith("#")) {
+                out.append("§x");
+                for (char c : serialized.substring(1).toCharArray()) {
+                    out.append('§').append(c);
+                }
+            } else {
+                out.append(ChatFormatting.valueOf(serialized.toUpperCase(ROOT)));
+            }
+            *///?}
         }
 
         if (style.isObfuscated()) {

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
@@ -200,7 +200,11 @@ public final class Utils {
                     out.append('§').append(c);
                 }
             } else {
-                out.append(ChatFormatting.valueOf(serialized.toUpperCase(ROOT)));
+                try {
+                    out.append(ChatFormatting.valueOf(serialized.toUpperCase(ROOT)));
+                } catch (IllegalArgumentException ignored) {
+                    //ignore unknown color names
+                }
             }
             *///?}
         }

--- a/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/Utils.java
@@ -194,12 +194,7 @@ public final class Utils {
             }
             //?} else {
             /*String serialized = color.serialize();
-            if (serialized.startsWith("#")) {
-                out.append("§x");
-                for (char c : serialized.substring(1).toCharArray()) {
-                    out.append('§').append(c);
-                }
-            } else {
+            if (!serialized.startsWith("#")) {
                 try {
                     out.append(ChatFormatting.valueOf(serialized.toUpperCase(ROOT)));
                 } catch (IllegalArgumentException ignored) {

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,0 +1,6 @@
+mc_version=26.2
+modrinth_minecraft_version_end=26.2
+fabric_version=0.154.2+26.2
+yacl_version=3.9.5+26.2-fabric
+modmenu_version=20.0.1
+release_type=alpha

--- a/versions/26.2/log4j-dev.xml
+++ b/versions/26.2/log4j-dev.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration name="BtrBz">
+  <Loggers>
+
+    <Logger additivity="false" level="${sys:btrbz.productResolver.log.level:-warn}"
+      name="com.github.lutzluca.btrbz.data.conversions.ProductResolver">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Logger additivity="false" level="${sys:btrbz.log.level:-debug}"
+      name="com.github.lutzluca.btrbz">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Logger additivity="false" level="warn" name="YetAnotherConfigLib">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Logger additivity="false" level="warn" name="net.minecraft">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Logger additivity="false" level="warn" name="com.mojang">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Root level="info">
+      <AppenderRef ref="SysOut"/>
+    </Root>
+
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This pr adds support for 26.2

### Changes


 Stonecutter: 
- Added 26.2 version with its gradle.properties and setup
- Added version branches for `Minecraft.getInstance().screen` -> `Minecraft.getInstance().gui.screen() `in approprate locations for 26.2
- Added version branches for `ChatFormatting.getByName()` since minecraft removed it, using `TextColor.serialize()` in 26.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Minecraft version 26.2.
  * Added release configuration for the 26.2 alpha build.
* **Compatibility**
  * Improved version-dependent screen handling (including opening/closing screens), menu slot detection, order book navigation, and sign value submission.
  * Updated chat formatting serialization for differing color formats across supported versions.
* **Logging**
  * Added a development Log4j configuration for the 26.2 target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->