### PR TITLE
Fix/partial conversion refresh

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
+++ b/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
@@ -258,7 +258,11 @@ public class BtrBz implements ClientModInitializer {
             case RefreshSuccess -> {
                 this.automaticConversionFailureNotified = false;
                 if (event.manual()) {
-                    MessageQueue.sendOrQueue("Updated Bazaar conversion index", Level.Info);
+                    if (event.message().isBlank()) {
+                        MessageQueue.sendOrQueue("Updated Bazaar conversion index", Level.Info);
+                    } else {
+                        MessageQueue.sendOrQueue(event.message(), Level.Warn);
+                    }
                 }
             }
             case PersistFailure -> {

--- a/src/main/java/com/github/lutzluca/btrbz/core/commands/ConversionCommand.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/commands/ConversionCommand.java
@@ -14,9 +14,7 @@ public final class ConversionCommand {
     private ConversionCommand() { }
 
     public static LiteralArgumentBuilder<FabricClientCommandSource> get(BazaarData bazaarData) {
-        return Commands.rootCommand
-            .then(command("conversions", bazaarData))
-            .then(command("conversion", bazaarData));
+        return Commands.rootCommand.then(command("conversions", bazaarData));
     }
 
     private static LiteralArgumentBuilder<FabricClientCommandSource> command(
@@ -33,22 +31,28 @@ public final class ConversionCommand {
                 }))
             .then(ClientCommands
                 .literal("refresh")
-                .executes(ctx -> {
-                    if (bazaarData.refreshConversions(true)) {
-                        Notifier.notifyPlayer(Notifier
-                            .prefix()
-                            .append(Component
-                                .literal("Started Bazaar conversion refresh")
-                                .withStyle(ChatFormatting.GRAY)));
-                    } else {
-                        Notifier.notifyPlayer(Notifier
-                            .prefix()
-                            .append(Component
-                                .literal("Bazaar conversion refresh is already running")
-                                .withStyle(ChatFormatting.GRAY)));
-                    }
-                    return 1;
-                }));
+                .executes(ctx -> startRefresh(bazaarData, false))
+                .then(ClientCommands
+                    .literal("force")
+                    .executes(ctx -> startRefresh(bazaarData, true))));
+    }
+
+    private static int startRefresh(BazaarData bazaarData, boolean force) {
+        if (bazaarData.refreshConversions(true, force)) {
+            var message = force
+                ? "Started forced Bazaar conversion refresh"
+                : "Started Bazaar conversion refresh";
+            Notifier.notifyPlayer(Notifier
+                .prefix()
+                .append(Component.literal(message).withStyle(ChatFormatting.GRAY)));
+        } else {
+            Notifier.notifyPlayer(Notifier
+                .prefix()
+                .append(Component
+                    .literal("Bazaar conversion refresh is already running")
+                    .withStyle(ChatFormatting.GRAY)));
+        }
+        return 1;
     }
 
     private static void notifyStatus(ConversionStatus status) {
@@ -58,6 +62,9 @@ public final class ConversionCommand {
             .append(Component.literal("Bazaar conversions").withStyle(ChatFormatting.GOLD))
             .append(Component.literal("\nSource: " + status.activeLoadSource()).withStyle(ChatFormatting.GRAY))
             .append(Component.literal("\nProducts: " + counts.total()).withStyle(ChatFormatting.GRAY))
+            .append(Component
+                .literal("\nMissing products: " + status.missingProductCount())
+                .withStyle(status.missingProductCount() == 0 ? ChatFormatting.GRAY : ChatFormatting.YELLOW))
             .append(Component
                 .literal("\nSources: neu=" + counts.neu()
                     + ", derived=" + counts.derived())

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -51,7 +51,11 @@ public class BazaarData {
     }
 
     public boolean refreshConversions(boolean manual) {
-        return this.conversionIndexService.refreshConversionIndex(manual);
+        return this.refreshConversions(manual, false);
+    }
+
+    public boolean refreshConversions(boolean manual, boolean force) {
+        return this.conversionIndexService.refreshConversionIndex(manual, force);
     }
 
     public ConversionStatus getConversionStatus() {

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndex.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndex.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public final class ConversionIndex {
 
@@ -20,7 +21,8 @@ public final class ConversionIndex {
         0,
         Instant.EPOCH.toString(),
         null,
-        Map.of()
+        Map.of(),
+        Set.of()
     );
 
     private final int schemaVersion;
@@ -28,6 +30,7 @@ public final class ConversionIndex {
     private final String generatedAt;
     private final String neuCommit;
     private final Map<String, ConversionProductEntry> products;
+    private final Set<String> missingProductIds;
     private final Map<String, List<IndexedProduct>> normalizedNameIndex;
 
     public ConversionIndex(
@@ -46,6 +49,17 @@ public final class ConversionIndex {
         String neuCommit,
         Map<String, ConversionProductEntry> products
     ) {
+        this(schemaVersion, builderVersion, generatedAt, neuCommit, products, Set.of());
+    }
+
+    public ConversionIndex(
+        int schemaVersion,
+        int builderVersion,
+        String generatedAt,
+        String neuCommit,
+        Map<String, ConversionProductEntry> products,
+        Set<String> missingProductIds
+    ) {
         if (schemaVersion != SCHEMA_VERSION) {
             throw new IllegalArgumentException("Unsupported conversion index schema version: " + schemaVersion);
         }
@@ -62,6 +76,9 @@ public final class ConversionIndex {
         this.products = Collections.unmodifiableMap(new LinkedHashMap<>(
             products == null ? Map.of() : products
         ));
+        this.missingProductIds = Set.copyOf(
+            missingProductIds == null ? Set.of() : missingProductIds
+        );
         this.normalizedNameIndex = buildNameIndex(this.products);
     }
 
@@ -87,6 +104,14 @@ public final class ConversionIndex {
 
     public Map<String, ConversionProductEntry> products() {
         return this.products;
+    }
+
+    public Set<String> missingProductIds() {
+        return this.missingProductIds;
+    }
+
+    public boolean isComplete() {
+        return this.missingProductIds.isEmpty();
     }
 
     public int size() {

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexService.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexService.java
@@ -79,6 +79,10 @@ public final class ConversionIndexService {
     }
 
     public boolean refreshConversionIndex(boolean manual) {
+        return this.refreshConversionIndex(manual, false);
+    }
+
+    public boolean refreshConversionIndex(boolean manual, boolean force) {
         if (!this.refreshInFlight.compareAndSet(false, true)) {
             this.emitConversionEvent(new ConversionEvent(
                     ConversionEvent.Kind.RefreshAlreadyRunning,
@@ -88,7 +92,7 @@ public final class ConversionIndexService {
         }
 
         CompletableFuture
-                .supplyAsync(() -> Try.of(this::prepareRemoteRefresh))
+                .supplyAsync(() -> Try.of(() -> this.prepareRemoteRefresh(force)))
                 .thenAccept(result -> Minecraft.getInstance().execute(() -> {
                     try {
                         result
@@ -196,8 +200,8 @@ public final class ConversionIndexService {
         this.conversionEventListeners.add(listener);
     }
 
-    private RemoteRefreshResult prepareRemoteRefresh() throws ConversionRefreshException {
-        var build = RemoteNeuConversionIndexBuilder.build(this.currentIndex);
+    private RemoteRefreshResult prepareRemoteRefresh(boolean allowPartial) throws ConversionRefreshException {
+        var build = RemoteNeuConversionIndexBuilder.build(this.currentIndex, allowPartial);
         if (!build.changed()) {
             return new RemoteRefreshResult(build.index(), false, Optional.empty());
         }
@@ -235,7 +239,9 @@ public final class ConversionIndexService {
             this.emitConversionEvent(new ConversionEvent(
                     ConversionEvent.Kind.RefreshSuccess,
                     manual,
-                    ""));
+                    result.index().isComplete()
+                        ? ""
+                        : "Applied partial index with " + result.index().missingProductIds().size() + " missing products"));
         }
     }
 
@@ -259,9 +265,10 @@ public final class ConversionIndexService {
     private void logIndexSummary(ConversionStatus.IndexLoadSource source, ConversionIndex index) {
         var counts = index.sourceCounts();
         log.debug(
-                "Applied conversion index from {} ({} products, source counts: neu={}, derived={})",
+                "Applied conversion index from {} ({} products, missing={}, source counts: neu={}, derived={})",
                 source,
                 index.size(),
+                index.missingProductIds().size(),
                 counts.neu(),
                 counts.derived());
         this.logDerivedMappings(index);

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionLoader.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionLoader.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.Minecraft;
@@ -47,7 +48,8 @@ final class ConversionLoader {
         int builderVersion,
         String generatedAt,
         String neuCommit,
-        Map<String, ConversionProductEntry> products
+        Map<String, ConversionProductEntry> products,
+        Set<String> missingProductIds
     ) {
 
         static IndexSnapshot fromIndex(ConversionIndex index) {
@@ -56,7 +58,8 @@ final class ConversionLoader {
                 index.builderVersion(),
                 index.generatedAt(),
                 index.neuCommit().orElse(null),
-                index.products()
+                index.products(),
+                index.missingProductIds()
             );
         }
 
@@ -74,7 +77,8 @@ final class ConversionLoader {
                     this.builderVersion,
                     this.generatedAt,
                     this.neuCommit,
-                    this.products
+                    this.products,
+                    this.missingProductIds
                 );
             } catch (IllegalArgumentException err) {
                 throw new IOException("Invalid conversion index", err);

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionStatus.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionStatus.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 public record ConversionStatus(
     IndexLoadSource activeLoadSource,
     ConversionSourceCounts sourceCounts,
+    int missingProductCount,
     Optional<String> neuCommit,
     String generatedAt,
     Optional<String> lastSuccessfulRefreshAt,
@@ -29,6 +30,7 @@ public record ConversionStatus(
         return new ConversionStatus(
             source,
             index.sourceCounts(),
+            index.missingProductIds().size(),
             index.neuCommit(),
             index.generatedAt(),
             lastSuccessfulRefreshAt,

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilder.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilder.java
@@ -66,7 +66,8 @@ final class RemoteNeuConversionIndexBuilder {
         Map.entry("RAW_FISH:3", "RAW_FISH-3"),
         Map.entry("SAND:1", "SAND-1"),
         Map.entry("BAZAAR_COOKIE", "BOOSTER_COOKIE"),
-        Map.entry("ENCHANTED_CARROT_ON_A_STICK", "ENCHANTED_CARROT_STICK")
+        Map.entry("ENCHANTED_CARROT_ON_A_STICK", "ENCHANTED_CARROT_STICK"),
+        Map.entry("SHARD_WETWING", "ATTRIBUTE_SHARD_HUMANOID_RULER_NEW;1")
     );
 
     private RemoteNeuConversionIndexBuilder() { }
@@ -258,15 +259,11 @@ final class RemoteNeuConversionIndexBuilder {
             return;
         }
 
-        var sample = missing.stream().limit(LOG_SAMPLE_LIMIT).toList();
         log.warn(
-            "Could not complete Bazaar conversion index refresh; {} products are missing NEU display metadata. Sample: {}",
+            "Could not complete Bazaar conversion index refresh; {} products are missing NEU display metadata: {}",
             missing.size(),
-            sample
+            missing
         );
-        if (log.isDebugEnabled()) {
-            log.debug("Missing Bazaar conversion products: {}", missing);
-        }
 
         throw new ConversionRefreshException(
             ConversionRefreshException.Phase.Validate,

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilder.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilder.java
@@ -38,7 +38,7 @@ final class RemoteNeuConversionIndexBuilder {
     private static final Duration ZIP_REQUEST_TIMEOUT = Duration.ofSeconds(60);
     private static final int LOG_SAMPLE_LIMIT = Integer.getInteger("btrbz.conversions.logSampleLimit", 0);
     private static final int MAX_ROMAN_LEVEL = 3999;
-    static final int BUILDER_VERSION = 1;
+    static final int BUILDER_VERSION = 2;
     private static final HttpClient HTTP_CLIENT = HttpClient
         .newBuilder()
         .connectTimeout(CONNECT_TIMEOUT)
@@ -75,6 +75,10 @@ final class RemoteNeuConversionIndexBuilder {
     record BuildResult(ConversionIndex index, boolean changed) { }
 
     static BuildResult build(ConversionIndex current) throws ConversionRefreshException {
+        return build(current, false);
+    }
+
+    static BuildResult build(ConversionIndex current, boolean allowPartial) throws ConversionRefreshException {
         var productIds = fetchBazaarProductIds();
         var neuCommit = fetchNeuCommit();
         var canReuseEntries = shouldReuseNeuEntries(current, neuCommit, productIds);
@@ -90,21 +94,30 @@ final class RemoteNeuConversionIndexBuilder {
             ? reusableEntries(current, productIds)
             : fetchNeuEntries(neuCommit, productIds);
 
-        validateCompleteIndex(productIds, products);
+        var missingProductIds = validateCompleteIndex(productIds, products, allowPartial);
+        var carriedForwardCount = carryForwardMissingEntries(current, products, missingProductIds);
+        if (carriedForwardCount > 0) {
+            log.warn(
+                "Carried forward {} stale conversion entries from the active index; they remain marked as missing",
+                carriedForwardCount
+            );
+        }
 
         var index = new ConversionIndex(
             ConversionIndex.SCHEMA_VERSION,
             BUILDER_VERSION,
             Instant.now().toString(),
             neuCommit,
-            products
+            products,
+            missingProductIds
         );
         var counts = index.sourceCounts();
         log.info(
-            "Built Bazaar conversion index from {} products: neu={}, derived={}, neuCommit={}",
+            "Built Bazaar conversion index from {} products: neu={}, derived={}, missing={}, neuCommit={}",
             index.size(),
             counts.neu(),
             counts.derived(),
+            index.missingProductIds().size(),
             neuCommit
         );
         return new BuildResult(index, true);
@@ -123,7 +136,30 @@ final class RemoteNeuConversionIndexBuilder {
             return false;
         }
 
+        if (!curr.isComplete()) {
+            return false;
+        }
+
         return productIds.stream().allMatch(productId -> curr.products().containsKey(productId));
+    }
+
+    static int carryForwardMissingEntries(
+        ConversionIndex current,
+        Map<String, ConversionProductEntry> products,
+        Set<String> missingProductIds
+    ) {
+        if (current == null || missingProductIds.isEmpty()) {
+            return 0;
+        }
+
+        var carriedForwardCount = 0;
+        for (var productId : missingProductIds) {
+            var currentEntry = current.products().get(productId);
+            if (currentEntry != null && products.putIfAbsent(productId, currentEntry) == null) {
+                carriedForwardCount++;
+            }
+        }
+        return carriedForwardCount;
     }
 
     private static Set<String> fetchBazaarProductIds() throws ConversionRefreshException {
@@ -249,14 +285,15 @@ final class RemoteNeuConversionIndexBuilder {
         }
     }
 
-    private static void validateCompleteIndex(
+    static Set<String> validateCompleteIndex(
         Set<String> productIds,
-        Map<String, ConversionProductEntry> products
+        Map<String, ConversionProductEntry> products,
+        boolean allowPartial
     ) throws ConversionRefreshException {
         var missing = new TreeSet<>(productIds);
         missing.removeAll(products.keySet());
         if (missing.isEmpty()) {
-            return;
+            return Set.of();
         }
 
         log.warn(
@@ -264,6 +301,10 @@ final class RemoteNeuConversionIndexBuilder {
             missing.size(),
             missing
         );
+
+        if (allowPartial) {
+            return Set.copyOf(missing);
+        }
 
         throw new ConversionRefreshException(
             ConversionRefreshException.Phase.Validate,

--- a/src/test/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -87,8 +88,51 @@ class ConversionIndexTest {
             assertFalse(json.contains("\"strippedName\""));
             assertEquals(7, parsed.builderVersion());
             assertEquals("Sharpness V", parsed.product("ENCHANTMENT_SHARPNESS_5").orElseThrow().strippedName());
+            assertTrue(parsed.isComplete());
             var neu = assertInstanceOf(ProductNameSource.Neu.class, source);
             assertEquals("SHARPNESS;5", neu.neuId());
+        }
+
+        @Test
+        void roundTripsMissingProductMarkers() throws Exception {
+            var index = new ConversionIndex(
+                ConversionIndex.SCHEMA_VERSION,
+                7,
+                "now",
+                "abc",
+                java.util.Map.of(
+                    "KNOWN",
+                    new ConversionProductEntry("Known", new ProductNameSource.Neu("KNOWN"))
+                ),
+                Set.of("MISSING")
+            );
+
+            var json = ConversionLoader.GSON.toJson(ConversionLoader.IndexSnapshot.fromIndex(index));
+            var parsed = ConversionLoader.GSON.fromJson(json, ConversionLoader.IndexSnapshot.class).toIndex();
+
+            assertFalse(parsed.isComplete());
+            assertEquals(Set.of("MISSING"), parsed.missingProductIds());
+        }
+
+        @Test
+        void treatsSnapshotsWithoutMissingProductMarkersAsComplete() throws Exception {
+            var json = """
+                {
+                  "schemaVersion": 1,
+                  "builderVersion": 1,
+                  "generatedAt": "now",
+                  "products": {
+                    "KNOWN": {
+                      "formattedName": "Known",
+                      "source": { "type": "neu", "neuId": "KNOWN" }
+                    }
+                  }
+                }
+                """;
+
+            var parsed = ConversionLoader.GSON.fromJson(json, ConversionLoader.IndexSnapshot.class).toIndex();
+
+            assertTrue(parsed.isComplete());
         }
 
         @Test

--- a/src/test/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilderTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/data/conversions/RemoteNeuConversionIndexBuilderTest.java
@@ -2,8 +2,10 @@ package com.github.lutzluca.btrbz.data.conversions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
@@ -93,6 +95,100 @@ class RemoteNeuConversionIndexBuilderTest {
             );
 
             assertFalse(reusable);
+        }
+
+        @Test
+        void fetchesWhenCurrentIndexIsIncomplete() {
+            var current = new ConversionIndex(
+                ConversionIndex.SCHEMA_VERSION,
+                RemoteNeuConversionIndexBuilder.BUILDER_VERSION,
+                "now",
+                "abc",
+                Map.of("NEU_PRODUCT", new ConversionProductEntry(
+                    "Neu Product",
+                    new ProductNameSource.Neu("NEU_PRODUCT")
+                )),
+                Set.of("MISSING_PRODUCT")
+            );
+
+            var reusable = RemoteNeuConversionIndexBuilder.shouldReuseNeuEntries(
+                current,
+                "abc",
+                Set.of("NEU_PRODUCT")
+            );
+
+            assertFalse(reusable);
+        }
+    }
+
+    @Nested
+    @DisplayName("completeness validation")
+    class CompletenessValidation {
+
+        @Test
+        void rejectsPartialIndexByDefault() {
+            assertThrows(
+                ConversionRefreshException.class,
+                () -> RemoteNeuConversionIndexBuilder.validateCompleteIndex(
+                    Set.of("KNOWN", "MISSING"),
+                    Map.of("KNOWN", new ConversionProductEntry(
+                        "Known",
+                        new ProductNameSource.Neu("KNOWN")
+                    )),
+                    false
+                )
+            );
+        }
+
+        @Test
+        void returnsMissingProductsWhenPartialIndexIsAllowed() throws Exception {
+            var missing = RemoteNeuConversionIndexBuilder.validateCompleteIndex(
+                Set.of("KNOWN", "MISSING"),
+                Map.of("KNOWN", new ConversionProductEntry(
+                    "Known",
+                    new ProductNameSource.Neu("KNOWN")
+                )),
+                true
+            );
+
+            assertEquals(Set.of("MISSING"), missing);
+        }
+
+        @Test
+        void carriesForwardOnlyMissingEntriesWithoutOverwritingFreshMappings() {
+            var current = indexWithNeuCommit(
+                "old",
+                Map.of(
+                    "UPDATED", new ConversionProductEntry(
+                        "Old Updated",
+                        new ProductNameSource.Neu("OLD_UPDATED")
+                    ),
+                    "STALE", new ConversionProductEntry(
+                        "Stale",
+                        new ProductNameSource.Neu("STALE")
+                    ),
+                    "REMOVED", new ConversionProductEntry(
+                        "Removed",
+                        new ProductNameSource.Neu("REMOVED")
+                    )
+                )
+            );
+            var freshUpdated = new ConversionProductEntry(
+                "Fresh Updated",
+                new ProductNameSource.Neu("FRESH_UPDATED")
+            );
+            var products = new LinkedHashMap<>(Map.of("UPDATED", freshUpdated));
+
+            var carriedForward = RemoteNeuConversionIndexBuilder.carryForwardMissingEntries(
+                current,
+                products,
+                Set.of("STALE")
+            );
+
+            assertEquals(1, carriedForward);
+            assertEquals(freshUpdated, products.get("UPDATED"));
+            assertEquals(current.products().get("STALE"), products.get("STALE"));
+            assertFalse(products.containsKey("REMOVED"));
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `force` option to manually refresh conversion data.
  * Partial conversion data can now be applied when some products are unavailable, while retaining existing entries where possible.
  * Conversion status now displays the number of missing products and indicates incomplete data.
* **Bug Fixes**
  * Refresh results now provide clearer messages when partial data is applied.
  * Successful refresh notifications can display relevant warnings when applicable.
* **Changes**
  * The `conversion` command alias was removed; use `conversions` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->