### PR TITLE
Performance improvements for new widget system

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/trackedorders/TrackedOrderManager.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/trackedorders/TrackedOrderManager.java
@@ -47,6 +47,7 @@ public class TrackedOrderManager {
     private final TrackedOrderStatusEvaluator statusEvaluator = new TrackedOrderStatusEvaluator();
     private final SelfUndercutDetector selfUndercutDetector = new SelfUndercutDetector();
     private long displayRevision;
+    private long dataRevision;
     private int filledOrderCount;
 
     private final List<Consumer<TrackedOrder>> onOrderAddedListeners = new ArrayList<>();
@@ -82,6 +83,7 @@ public class TrackedOrderManager {
 
         var oldSelfUndercutKey = TrackedOrderGrouping.SelfUndercutMatchKey.from(order);
         order.applyProduct(mergedProduct);
+        this.dataRevision++;
 
         if (oldKey.equals(newKey)) {
             log.debug(
@@ -150,7 +152,11 @@ public class TrackedOrderManager {
                 case UnfilledOrderInfo unfilled -> unfilledOrders.add(unfilled);
             }
         }
-        this.filledOrderCount = filledOrders.size();
+
+        if (this.filledOrderCount != filledOrders.size()) {
+            this.filledOrderCount = filledOrders.size();
+            this.dataRevision++;
+        }
 
         var unfilledCopy = new ArrayList<>(unfilledOrders);
 
@@ -161,8 +167,13 @@ public class TrackedOrderManager {
                 info -> {
                     unfilledCopy.remove(info);
                     this.updateTrackedProduct(tracked, info.product());
-                    tracked.slot = info.slotIdx();
-                    tracked.fillAmountSnapshot = info.filledAmountSnapshot();
+                    int slot = info.slotIdx();
+                    int fill = info.filledAmountSnapshot();
+                    if (tracked.slot != slot || tracked.fillAmountSnapshot != fill) {
+                        this.dataRevision++;
+                        tracked.slot = slot;
+                        tracked.fillAmountSnapshot = fill;
+                    }
                 }, () -> toRemove.add(tracked)
             );
         }
@@ -187,6 +198,7 @@ public class TrackedOrderManager {
         if (this.trackedOrders.remove(order)) {
             this.displayOrders.remove(order);
             this.displayRevision++;
+            this.dataRevision++;
             this.selfUndercutDetector.removeIfLastOrder(order, this.trackedOrders);
             this.onOrderRemovedListeners.forEach(listener -> listener.accept(order));
         }
@@ -198,6 +210,9 @@ public class TrackedOrderManager {
             .toList();
 
         statusUpdates.forEach(update -> update.order().status = update.curr());
+        if (!statusUpdates.isEmpty()) {
+            this.dataRevision++;
+        }
 
         var notificationUpdates = statusUpdates.stream()
             .filter(update -> !update.prev().sameVariant(update.curr()))
@@ -305,6 +320,7 @@ public class TrackedOrderManager {
         this.displayOrders.clear();
         this.selfUndercutDetector.clear();
         this.displayRevision++;
+        this.dataRevision++;
         this.filledOrderCount = 0;
 
         log.info("Reset tracked orders (removed {})", removedSize);
@@ -326,6 +342,10 @@ public class TrackedOrderManager {
 
     public long displayRevision() {
         return this.displayRevision;
+    }
+
+    public long dataRevision() {
+        return this.dataRevision;
     }
 
     public int filledOrderCount() {
@@ -350,6 +370,7 @@ public class TrackedOrderManager {
         insertionIndex = Math.min(insertionIndex, this.displayOrders.size());
         this.displayOrders.add(insertionIndex, order);
         this.displayRevision++;
+        this.dataRevision++;
 
         return true;
     }
@@ -358,6 +379,7 @@ public class TrackedOrderManager {
         this.trackedOrders.add(order);
         this.displayOrders.add(order);
         this.displayRevision++;
+        this.dataRevision++;
         this.onOrderAddedListeners.forEach(listener -> listener.accept(order));
     }
 
@@ -391,6 +413,7 @@ public class TrackedOrderManager {
 
     public void handleOrderFilled(OrderFilled info) {
         this.filledOrderCount++;
+        this.dataRevision++;
         var orderingFactor = info.type() == OrderType.Buy ? -1 : 1;
 
         // noinspection SimplifyStreamApiCallChains

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetCacheKey.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetCacheKey.java
@@ -1,0 +1,4 @@
+package com.github.lutzluca.btrbz.core.widgets;
+
+public interface WidgetCacheKey {
+}

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetDefinition.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
 
 /** The complete typed recipe for one BtrBz widget. */
 @Getter
@@ -27,6 +28,7 @@ public final class WidgetDefinition<D, C, A> {
     private final Predicate<WidgetSession> supports;
     private final WidgetVisibility<D, C> visibility;
     private final Function<WidgetSession, D> runtimeData;
+    private final @Nullable Function<WidgetSession, Object> cacheKey;
     private final Supplier<WidgetPreview<D>> preview;
     private final Supplier<WidgetView<D, C, A>> viewFactory;
     private final Function<WidgetConfigBinding<C>, UIComponent> settingsPanel;
@@ -46,6 +48,7 @@ public final class WidgetDefinition<D, C, A> {
         this.supports = Objects.requireNonNull(builder.supports, "supports");
         this.visibility = Objects.requireNonNull(builder.visibility, "visibility");
         this.runtimeData = Objects.requireNonNull(builder.runtimeData, "runtimeData");
+        this.cacheKey = builder.cacheKey;
         this.preview = Objects.requireNonNull(builder.preview, "preview");
         this.viewFactory = Objects.requireNonNull(builder.viewFactory, "viewFactory");
         this.settingsPanel = Objects.requireNonNull(builder.settingsPanel, "settingsPanel");
@@ -85,6 +88,11 @@ public final class WidgetDefinition<D, C, A> {
         var profile = this.placementProfileResolver.apply(session);
         return this.placementProfiles.containsKey(profile) ? profile : "default";
     }
+
+    public @Nullable Object cacheKey(WidgetSession session) {
+        return this.cacheKey == null ? null : this.cacheKey.apply(session);
+    }
+
     public WidgetConfigBinding<C> binding(Runnable changed) {
         return new WidgetConfigBinding<>(
             this.currentConfig, this.freshDefaults, this.frameConfig, this.resetPreferences, changed
@@ -109,6 +117,7 @@ public final class WidgetDefinition<D, C, A> {
         private Predicate<WidgetSession> supports = _ -> true;
         private WidgetVisibility<D, C> visibility = (data, config, session) -> true;
         private Function<WidgetSession, D> runtimeData;
+        private @Nullable Function<WidgetSession, Object> cacheKey;
         private Supplier<WidgetPreview<D>> preview;
         private Supplier<WidgetView<D, C, A>> viewFactory;
         private Function<WidgetConfigBinding<C>, UIComponent> settingsPanel = _ -> null;
@@ -149,6 +158,12 @@ public final class WidgetDefinition<D, C, A> {
             this.runtimeData = runtimeData;
             return this;
         }
+
+        public Builder<D, C, A> cacheKey(Function<WidgetSession, Object> cacheKey) {
+            this.cacheKey = cacheKey;
+            return this;
+        }
+
         public Builder<D, C, A> preview(Supplier<WidgetPreview<D>> preview) {
             this.preview = preview;
             return this;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/WidgetDefinition.java
@@ -28,7 +28,7 @@ public final class WidgetDefinition<D, C, A> {
     private final Predicate<WidgetSession> supports;
     private final WidgetVisibility<D, C> visibility;
     private final Function<WidgetSession, D> runtimeData;
-    private final @Nullable Function<WidgetSession, Object> cacheKey;
+    private final @Nullable Function<WidgetSession, WidgetCacheKey> cacheKey;
     private final Supplier<WidgetPreview<D>> preview;
     private final Supplier<WidgetView<D, C, A>> viewFactory;
     private final Function<WidgetConfigBinding<C>, UIComponent> settingsPanel;
@@ -89,7 +89,7 @@ public final class WidgetDefinition<D, C, A> {
         return this.placementProfiles.containsKey(profile) ? profile : "default";
     }
 
-    public @Nullable Object cacheKey(WidgetSession session) {
+    public @Nullable WidgetCacheKey cacheKey(WidgetSession session) {
         return this.cacheKey == null ? null : this.cacheKey.apply(session);
     }
 
@@ -117,7 +117,7 @@ public final class WidgetDefinition<D, C, A> {
         private Predicate<WidgetSession> supports = _ -> true;
         private WidgetVisibility<D, C> visibility = (data, config, session) -> true;
         private Function<WidgetSession, D> runtimeData;
-        private @Nullable Function<WidgetSession, Object> cacheKey;
+        private @Nullable Function<WidgetSession, WidgetCacheKey> cacheKey;
         private Supplier<WidgetPreview<D>> preview;
         private Supplier<WidgetView<D, C, A>> viewFactory;
         private Function<WidgetConfigBinding<C>, UIComponent> settingsPanel = _ -> null;
@@ -159,7 +159,7 @@ public final class WidgetDefinition<D, C, A> {
             return this;
         }
 
-        public Builder<D, C, A> cacheKey(Function<WidgetSession, Object> cacheKey) {
+        public Builder<D, C, A> cacheKey(Function<WidgetSession, WidgetCacheKey> cacheKey) {
             this.cacheKey = cacheKey;
             return this;
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarkComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarkComponent.java
@@ -28,6 +28,7 @@ public final class BookmarkComponent {
     private final TrackedOrderManager trackedOrders;
     private final Set<String> buyProducts = new HashSet<>();
     private final Set<String> sellProducts = new HashSet<>();
+    private long dataRevision;
 
     public BookmarkComponent(
         BazaarData bazaarData,
@@ -75,14 +76,19 @@ public final class BookmarkComponent {
 
     public boolean remove(String productId) {
         boolean changed = items().removeIf(item -> item.product().productId().equals(productId));
-        if (changed) ConfigManager.save();
+        if (changed) {
+            this.dataRevision++;
+            ConfigManager.save();
+        }
         return changed;
     }
 
     /** Uses a drop-boundary insertion index in {@code 0..size}. */
     public boolean reorder(String productId, int insertionIndex) {
         var items = items();
-        if (insertionIndex < 0 || insertionIndex > items.size()) return false;
+        if (insertionIndex < 0 || insertionIndex > items.size()) {
+            return false;
+        }
         int source = -1;
         for (int i = 0; i < items.size(); i++) {
             if (items.get(i).product().productId().equals(productId)) {
@@ -90,22 +96,28 @@ public final class BookmarkComponent {
                 break;
             }
         }
-        if (source < 0) return false;
+        if (source < 0){
+            return false;
+        }
         var item = items.remove(source);
         int target = insertionIndex > source ? insertionIndex - 1 : insertionIndex;
         items.add(Math.min(target, items.size()), item);
+        this.dataRevision++;
         ConfigManager.save();
         return true;
     }
 
     private boolean toggle(ItemStack stack) {
         var product = this.productInfoProvider.getOpenedProduct();
-        if (product == null) return false;
+        if (product == null) {
+            return false;
+        }
         if (this.contains(product.productId())) {
             this.remove(product.productId());
             return false;
         }
         items().add(new BookmarkedItem(product, stack.copy()));
+        this.dataRevision++;
         ConfigManager.save();
         return true;
     }
@@ -121,7 +133,10 @@ public final class BookmarkComponent {
                 changed = true;
             }
         }
-        if (changed) ConfigManager.save();
+        if (changed) {
+            this.dataRevision++;
+            ConfigManager.save();
+        }
     }
 
     private void rebuildOrderCache() {
@@ -133,10 +148,15 @@ public final class BookmarkComponent {
                 case Sell -> this.sellProducts.add(id);
             }
         }));
+        this.dataRevision++;
     }
 
     private static List<BookmarkedItem> items() {
         return ConfigManager.get().widgets.bookmarks.items;
+    }
+
+    public long dataRevision() {
+        return this.dataRevision;
     }
 
     public record Snapshot(

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarksWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarksWidgetDefinition.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.bookmarks;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
@@ -23,6 +24,16 @@ public final class BookmarksWidgetDefinition {
             .supports(WidgetSession::inBazaarContainer)
             .visibility((data, _, _) -> !data.bookmarks().isEmpty())
             .runtimeData(_ -> provider.snapshot())
+            .runtimeData(_ -> provider.snapshot())
+            .cacheKey(_ -> {
+                var config = ConfigManager.get().widgets.bookmarks;
+                return new CacheKey(
+                    component.dataRevision(),
+                    config.contentWidth,
+                    config.visibleRows,
+                    config.sort
+                );
+            })
             .preview(() -> new WidgetPreview<>(BookmarksWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.Main), "default"))
             .viewFactory(BookmarksWidgetView::new)
             .actionHandler(new BookmarksActionHandler(component))
@@ -30,4 +41,11 @@ public final class BookmarksWidgetDefinition {
             .minSize(WidgetLayoutTokens.panelWidth(200), 16)
             .build();
     }
+
+    private record CacheKey(
+        long data,
+        int contentWidth,
+        int visibleRows,
+        BookmarksWidgetConfig.BookmarkSort sort
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/config/WidgetStateStore.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/config/WidgetStateStore.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 public final class WidgetStateStore {
     private final Supplier<WidgetsConfig> configSupplier;
     private final Runnable saveAction;
+    private long frameRevision;
 
     public WidgetStateStore() { this(() -> ConfigManager.get().widgets, ConfigManager::save); }
 
@@ -19,12 +20,17 @@ public final class WidgetStateStore {
         this.saveAction = Objects.requireNonNull(saveAction, "saveAction");
     }
 
+    public long frameRevision() {
+        return this.frameRevision;
+    }
+
     public double globalFineTuneScale() { return WidgetScaleResolver.clampScale(this.config().globalFineTuneScale); }
     public void setGlobalFineTuneScale(double value) {
         this.setGlobalFineTuneScale(value, true);
     }
     public void setGlobalFineTuneScale(double value, boolean persist) {
         this.config().globalFineTuneScale = WidgetScaleResolver.clampScale(value);
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public int globalBackgroundColor() { return this.config().globalBackground; }
@@ -33,6 +39,7 @@ public final class WidgetStateStore {
     }
     public void setGlobalBackgroundColor(int color, boolean persist) {
         this.config().globalBackground = color;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public int managerPanelWidth() {
@@ -82,6 +89,7 @@ public final class WidgetStateStore {
     }
     public void setActive(WidgetDefinition<?, ?, ?> definition, boolean active, boolean persist) {
         definition.frame().enabled = active;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void setPlacement(
@@ -91,6 +99,7 @@ public final class WidgetStateStore {
         boolean persist
     ) {
         definition.frame().placements.put(profile, placement);
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void resetPlacement(WidgetDefinition<?, ?, ?> definition, String profile) {
@@ -117,6 +126,7 @@ public final class WidgetStateStore {
         boolean persist
     ) {
         definition.frame().overrideScale = enabled;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void setWidgetScale(WidgetDefinition<?, ?, ?> definition, double value) {
@@ -124,6 +134,7 @@ public final class WidgetStateStore {
     }
     public void setWidgetScale(WidgetDefinition<?, ?, ?> definition, double value, boolean persist) {
         definition.frame().scale = WidgetScaleResolver.clampScale(value);
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void resetWidgetScale(WidgetDefinition<?, ?, ?> definition) {
@@ -134,6 +145,7 @@ public final class WidgetStateStore {
         var defaults = definition.defaultFrame();
         frame.overrideScale = defaults.overrideScale;
         frame.scale = defaults.scale;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public double requestedScale(WidgetDefinition<?, ?, ?> definition) {
@@ -158,6 +170,7 @@ public final class WidgetStateStore {
         boolean persist
     ) {
         definition.frame().overrideBackground = enabled;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public int backgroundColor(WidgetDefinition<?, ?, ?> definition) {
@@ -170,6 +183,7 @@ public final class WidgetStateStore {
     }
     public void setBackgroundColor(WidgetDefinition<?, ?, ?> definition, int color, boolean persist) {
         definition.frame().background = color;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void resetBackgroundColor(WidgetDefinition<?, ?, ?> definition) {
@@ -180,6 +194,7 @@ public final class WidgetStateStore {
         var defaults = definition.defaultFrame();
         frame.overrideBackground = defaults.overrideBackground;
         frame.background = defaults.background;
+        this.frameRevision++;
         if (persist) this.saveAction.run();
     }
     public void save() { this.saveAction.run(); }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/dailylimit/DailyLimitWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/dailylimit/DailyLimitWidgetDefinition.java
@@ -1,13 +1,18 @@
 package com.github.lutzluca.btrbz.core.widgets.dailylimit;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetPreviewSessions;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetLayoutTokens;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
+import com.github.lutzluca.btrbz.core.widgets.ui.WidgetDisplayOptions.NumberStyle;
 import net.minecraft.resources.Identifier;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 public final class DailyLimitWidgetDefinition {
     public static final WidgetId ID = WidgetId.of(Identifier.fromNamespaceAndPath("btrbz", "order_limit"));
@@ -22,10 +27,30 @@ public final class DailyLimitWidgetDefinition {
                 config -> config.frame, DailyLimitWidgetConfig::resetPreferences)
             .supports(session -> session.inAnyBazaarMenu(BazaarMenuType.Main, BazaarMenuType.ItemGroup))
             .runtimeData(_ -> data.snapshot())
+            .cacheKey(_ -> {
+                var config = ConfigManager.get().widgets.orderLimit;
+                return new CacheKey(
+                    LocalDate.now(ZoneOffset.UTC).toEpochDay(),
+                    config.usedToday,
+                    config.dailyLimit,
+                    config.lastResetEpochDay,
+                    config.numberStyle
+                );
+            })
             .preview(() -> new WidgetPreview<>(DailyLimitWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.Main), "default"))
             .viewFactory(DailyLimitWidgetView::new)
             .settingsPanel(DailyLimitWidgetSettings::create)
             .minSize(WidgetLayoutTokens.panelWidth(MINIMUM_CONTENT_WIDTH), 30)
             .build();
     }
+
+    private record CacheKey(
+        long today,
+        double usedToday,
+        double dailyLimit,
+        long lastResetEpochDay,
+        NumberStyle numberStyle
+    ) implements WidgetCacheKey {}
+
+
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
@@ -3,6 +3,7 @@ package com.github.lutzluca.btrbz.core.widgets.data;
 import com.github.lutzluca.btrbz.core.OrderTooltipProvider;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
 import com.github.lutzluca.btrbz.core.trackedorders.TrackedOrderManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderStatus;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
@@ -38,14 +39,14 @@ public final class OrdersWidgetData {
     private @Nullable SnapshotKey cachedKey;
     private @Nullable BazaarWidgetViewData.OrdersData cachedData;
 
-    private record SnapshotKey(
+    public record SnapshotKey(
         long orders,
         long market,
         long index,
         long screen,
         long inventory,
         boolean tooltipsEnabled
-    ) {}
+    ) implements WidgetCacheKey {}
 
     public OrdersWidgetData(
         BazaarData market,
@@ -57,17 +58,9 @@ public final class OrdersWidgetData {
         this.tooltipProvider = tooltipProvider;
     }
 
-
-    public BazaarWidgetViewData.OrdersData snapshot() {
-        var snapshots = this.trackedOrders.currentOrders();
-        if (snapshots.isEmpty()) {
-            this.cachedKey = null;
-            this.cachedData = null;
-            return new BazaarWidgetViewData.OrdersData(List.of(), this.trackedOrders.filledOrderCount());
-        }
-
+    public SnapshotKey snapshotKey() {
         var screens = ScreenInfoHelper.get();
-        var key = new SnapshotKey(
+        return new SnapshotKey(
             this.trackedOrders.dataRevision(),
             this.market.marketRevision(),
             this.market.indexRevision(),
@@ -75,6 +68,10 @@ public final class OrdersWidgetData {
             screens.inventoryVersion(),
             ConfigManager.get().orderListTooltip.enabled
         );
+    }
+
+    public BazaarWidgetViewData.OrdersData snapshot() {
+        var key = this.snapshotKey();
 
         var cached = this.cachedData;
         if (cached != null && key.equals(this.cachedKey)) {
@@ -87,7 +84,7 @@ public final class OrdersWidgetData {
         return computed;
     }
 
-    private BazaarWidgetViewData.OrdersData computeSnapshot() {
+     BazaarWidgetViewData.OrdersData computeSnapshot() {
         var snapshots = this.trackedOrders.currentOrders();
         if (snapshots.isEmpty()) {
             return new BazaarWidgetViewData.OrdersData(List.of(), this.trackedOrders.filledOrderCount());

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
@@ -39,14 +39,6 @@ public final class OrdersWidgetData {
     private @Nullable SnapshotKey cachedKey;
     private @Nullable BazaarWidgetViewData.OrdersData cachedData;
 
-    public record SnapshotKey(
-        long orders,
-        long market,
-        long index,
-        long screen,
-        long inventory,
-        boolean tooltipsEnabled
-    ) implements WidgetCacheKey {}
 
     public OrdersWidgetData(
         BazaarData market,
@@ -224,4 +216,13 @@ public final class OrdersWidgetData {
         if (item == Items.EMERALD) return component.withStyle(ChatFormatting.GREEN);
         return component.withStyle(ChatFormatting.GRAY);
     }
+
+    public record SnapshotKey(
+        long orders,
+        long market,
+        long index,
+        long screen,
+        long inventory,
+        boolean tooltipsEnabled
+    ) {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetData.java
@@ -27,12 +27,25 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.Nullable;
 
 /** Shared defensive order snapshots used by the HUD and tracked-orders widgets. */
 public final class OrdersWidgetData {
     private final BazaarData market;
     private final TrackedOrderManager trackedOrders;
     private final OrderTooltipProvider tooltipProvider;
+
+    private @Nullable SnapshotKey cachedKey;
+    private @Nullable BazaarWidgetViewData.OrdersData cachedData;
+
+    private record SnapshotKey(
+        long orders,
+        long market,
+        long index,
+        long screen,
+        long inventory,
+        boolean tooltipsEnabled
+    ) {}
 
     public OrdersWidgetData(
         BazaarData market,
@@ -44,7 +57,37 @@ public final class OrdersWidgetData {
         this.tooltipProvider = tooltipProvider;
     }
 
+
     public BazaarWidgetViewData.OrdersData snapshot() {
+        var snapshots = this.trackedOrders.currentOrders();
+        if (snapshots.isEmpty()) {
+            this.cachedKey = null;
+            this.cachedData = null;
+            return new BazaarWidgetViewData.OrdersData(List.of(), this.trackedOrders.filledOrderCount());
+        }
+
+        var screens = ScreenInfoHelper.get();
+        var key = new SnapshotKey(
+            this.trackedOrders.dataRevision(),
+            this.market.marketRevision(),
+            this.market.indexRevision(),
+            screens.screenTransitionVersion(),
+            screens.inventoryVersion(),
+            ConfigManager.get().orderListTooltip.enabled
+        );
+
+        var cached = this.cachedData;
+        if (cached != null && key.equals(this.cachedKey)) {
+            return cached;
+        }
+
+        var computed = this.computeSnapshot();
+        this.cachedKey = key;
+        this.cachedData = computed;
+        return computed;
+    }
+
+    private BazaarWidgetViewData.OrdersData computeSnapshot() {
         var snapshots = this.trackedOrders.currentOrders();
         if (snapshots.isEmpty()) {
             return new BazaarWidgetViewData.OrdersData(List.of(), this.trackedOrders.filledOrderCount());

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetDefinition.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.hud;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
@@ -24,10 +25,38 @@ public final class BazaarOrdersWidgetDefinition {
             .supports(WidgetSession::inHud)
             .visibility((data, _, _) -> !data.orders().isEmpty() || data.filledOrderCount() > 0)
             .runtimeData(_ -> provider.snapshot())
+            .cacheKey(_ -> {
+                var config = ConfigManager.get().widgets.bazaarOrders;
+                return new CacheKey(
+                    provider.snapshotKey(),
+                    new ConfigSnapshot(
+                        config.mode,
+                        config.visibleOrders,
+                        config.contentWidth,
+                        config.abbreviateEnchanted,
+                        config.showQueue,
+                        config.showUndercutGap
+                    )
+                );
+            })
             .preview(() -> new WidgetPreview<>(OrdersWidgetData.preview(), WidgetPreviewSessions.hud(), "default"))
             .viewFactory(BazaarOrdersWidgetView::new)
             .settingsPanel(BazaarOrdersWidgetSettings::create)
             .minSize(WidgetLayoutTokens.panelWidth(BazaarHudOptions.MINIMUM_CONTENT_WIDTH), 28)
             .build();
     }
+
+    private record ConfigSnapshot(
+        BazaarOrdersWidgetConfig.HudMode mode,
+        int visibleOrders,
+        int contentWidth,
+        boolean abbreviateEnchanted,
+        boolean showQueue,
+        boolean showUndercutGap
+    ) {}
+
+    private record CacheKey(
+        OrdersWidgetData.SnapshotKey data,
+        ConfigSnapshot config
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetView.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
@@ -94,7 +95,10 @@ final class BazaarOrdersWidgetView implements WidgetView<
                 row.update(order, config);
                 this.rows.child(row);
             }
-            var currentIds = data.orders().stream().map(BazaarWidgetViewData.Order::id).toList();
+
+            var currentIds = data.orders().stream()
+                .map(BazaarWidgetViewData.Order::id)
+                .collect(Collectors.toSet());
             this.rowsById.keySet().removeIf(id -> !currentIds.contains(id));
 
             this.root.clearChildren();
@@ -199,12 +203,15 @@ final class BazaarOrdersWidgetView implements WidgetView<
         }
 
         private void update(List<BazaarWidgetViewData.Order> orders) {
-            long[] counts = {
-                count(orders, BazaarWidgetViewData.OrderStatus.Undercut),
-                count(orders, BazaarWidgetViewData.OrderStatus.Matched),
-                count(orders, BazaarWidgetViewData.OrderStatus.Top),
-                count(orders, BazaarWidgetViewData.OrderStatus.Unknown)
-            };
+            long[] counts = new long[4];
+            for (var order : orders) {
+                switch (order.status()) {
+                    case Undercut -> counts[0]++;
+                    case Matched -> counts[1]++;
+                    case Top -> counts[2]++;
+                    case Unknown -> counts[3]++;
+                }
+            }
             this.more.text(Component.literal("+" + orders.size() + " more ·"));
             this.root.clearChildren();
             this.root.child(this.more);
@@ -213,10 +220,6 @@ final class BazaarOrdersWidgetView implements WidgetView<
                 this.statuses.get(index).update(counts[index]);
                 this.root.child(this.statuses.get(index).root);
             }
-        }
-
-        private static long count(List<BazaarWidgetViewData.Order> orders, BazaarWidgetViewData.OrderStatus status) {
-            return orders.stream().filter(order -> order.status() == status).count();
         }
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookPriceWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookPriceWidgetDefinition.java
@@ -1,11 +1,11 @@
 package com.github.lutzluca.btrbz.core.widgets.orderbook;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetPreviewSessions;
-import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetLayoutTokens;
 import net.minecraft.resources.Identifier;
 
@@ -21,6 +21,16 @@ public final class OrderBookPriceWidgetDefinition {
                 config -> config.frame, OrderBookPriceWidgetConfig::resetPreferences)
             .supports(session -> session.inSign() && session.product().isPresent() && session.side().isPresent())
             .runtimeData(provider::snapshot)
+            .cacheKey(session -> {
+                var config = ConfigManager.get().widgets.orderBookPrice;
+                return new CacheKey(
+                    provider.stateKey(session),
+                    config.contentWidth,
+                    config.visibleRows,
+                    config.showOrderCount,
+                    config.sideDisplay
+                );
+            })
             .preview(() -> {
                 var data = OrderBookWidgetData.preview();
                 return new WidgetPreview<>(data, WidgetPreviewSessions.sign(data), "default");
@@ -31,4 +41,12 @@ public final class OrderBookPriceWidgetDefinition {
             .minSize(WidgetLayoutTokens.panelWidth(118), 48)
             .build();
     }
+
+    private record CacheKey(
+        OrderBookWidgetData.StateKey state,
+        int contentWidth,
+        int visibleRows,
+        boolean showOrderCount,
+        OrderBookPriceWidgetConfig.EmbeddedSideDisplay sideDisplay
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookWidgetData.java
@@ -5,11 +5,13 @@ import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
 import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.data.OrderModels.OrderType;
 import com.github.lutzluca.btrbz.data.ProductIdentity;
+import com.github.lutzluca.btrbz.core.widgets.session.WidgetProductContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import org.jetbrains.annotations.Nullable;
 
 /** Shared order-book snapshots for the custom-screen and sign widgets. */
 public final class OrderBookWidgetData {
@@ -17,6 +19,14 @@ public final class OrderBookWidgetData {
 
     public OrderBookWidgetData(BazaarData market) {
         this.market = market;
+    }
+
+    public StateKey stateKey(WidgetSession session) {
+        return new StateKey(
+            session.product().map(WidgetProductContext::productId).orElse(null),
+            this.market.marketRevision(),
+            this.market.indexRevision()
+        );
     }
 
     public Snapshot snapshot(WidgetSession session) {
@@ -87,6 +97,12 @@ public final class OrderBookWidgetData {
             return BazaarWidgetViewData.formatInt(this.quantity);
         }
     }
+
+    public record StateKey(
+        @Nullable String productId,
+        long marketRevision,
+        long indexRevision
+    ) {}
 
     public record Snapshot(
         String itemName,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookWidgetDefinition.java
@@ -1,11 +1,12 @@
 package com.github.lutzluca.btrbz.core.widgets.orderbook;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetPreviewSessions;
-import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
+import com.github.lutzluca.btrbz.core.widgets.ui.WidgetDisplayOptions.NumberStyle;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetLayoutTokens;
 import net.minecraft.resources.Identifier;
 
@@ -21,6 +22,17 @@ public final class OrderBookWidgetDefinition {
                 config -> config.frame, OrderBookWidgetConfig::resetPreferences)
             .supports(session -> session.inOrderBook() && session.product().isPresent())
             .runtimeData(provider::snapshot)
+            .cacheKey(session -> {
+                var config = ConfigManager.get().widgets.orderBookScreen;
+                return new CacheKey(
+                    provider.stateKey(session),
+                    config.contentWidth,
+                    config.visibleRows,
+                    config.layout,
+                    config.numberStyle,
+                    config.showOrderCount
+                );
+            })
             .preview(() -> {
                 var data = OrderBookWidgetData.preview();
                 return new WidgetPreview<>(data, WidgetPreviewSessions.orderBook(data), "default");
@@ -31,4 +43,13 @@ public final class OrderBookWidgetDefinition {
             .minSize(WidgetLayoutTokens.panelWidth(220), 48)
             .build();
     }
+
+    private record CacheKey(
+        OrderBookWidgetData.StateKey state,
+        int contentWidth,
+        int visibleRows,
+        OrderBookWidgetConfig.BookLayout layout,
+        NumberStyle numberStyle,
+        boolean showOrderCount
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueComponent.java
@@ -8,15 +8,22 @@ import java.util.List;
 public final class OrderValueComponent {
     private List<UnfilledOrderInfo> unfilledOrders = List.of();
     private List<FilledOrderInfo> filledOrders = List.of();
+    private long dataRevision;
+
+    public long dataRevision() {
+        return this.dataRevision;
+    }
 
     public void sync(List<UnfilledOrderInfo> unfilledOrders, List<FilledOrderInfo> filledOrders) {
         this.unfilledOrders = List.copyOf(unfilledOrders);
         this.filledOrders = List.copyOf(filledOrders);
+        this.dataRevision++;
     }
 
     public void clear() {
         this.unfilledOrders = List.of();
         this.filledOrders = List.of();
+        this.dataRevision++;
     }
 
     public Breakdown currentBreakdown() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetConfig.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetConfig.java
@@ -8,6 +8,13 @@ public final class OrderValueWidgetConfig {
     public WidgetFrameConfig frame = new WidgetFrameConfig(WidgetPlacement.topLeft(0.393, 0.077));
     public int contentWidth = 205;
     public ValueDisplay display = ValueDisplay.Detailed;
+
+    public record Snapshot(int contentWidth, ValueDisplay display) {
+        public static Snapshot of(OrderValueWidgetConfig config) {
+            return new Snapshot(config.contentWidth, config.display);
+        }
+    }
+
     public static void resetPreferences(OrderValueWidgetConfig current, OrderValueWidgetConfig defaults) {
         current.contentWidth = defaults.contentWidth;
         current.display = defaults.display;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetData.java
@@ -1,18 +1,32 @@
 package com.github.lutzluca.btrbz.core.widgets.ordervalue;
 
+import org.jetbrains.annotations.Nullable;
+
 public final class OrderValueWidgetData {
     private final OrderValueComponent component;
+    private long cachedRevision = Long.MIN_VALUE;
+    private @Nullable Snapshot cachedSnapshot;
 
     public OrderValueWidgetData(OrderValueComponent component) {
         this.component = component;
     }
 
     public Snapshot snapshot() {
+        long revision = this.component.dataRevision();
+        var cached = this.cachedSnapshot;
+        if (cached != null && revision == this.cachedRevision) {
+            return cached;
+        }
+
         var value = this.component.currentBreakdown();
-        return new Snapshot(
-            Math.round(value.buyLocked()), Math.round(value.buyItems()), Math.round(value.sellClaimable()),
-            Math.round(value.sellPending()), Math.round(value.total())
+        var computed = new Snapshot(
+            Math.round(value.buyLocked()), Math.round(value.buyItems()),
+            Math.round(value.sellClaimable()), Math.round(value.sellPending()),
+            Math.round(value.total())
         );
+        this.cachedRevision = revision;
+        this.cachedSnapshot = computed;
+        return computed;
     }
 
     public static Snapshot preview() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetDefinition.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.ordervalue;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
@@ -21,10 +22,19 @@ public final class OrderValueWidgetDefinition {
                 config -> config.frame, OrderValueWidgetConfig::resetPreferences)
             .supports(session -> session.inBazaarMenu(BazaarMenuType.Orders))
             .runtimeData(_ -> data.snapshot())
+            .cacheKey(_ -> new CacheKey(
+                component.dataRevision(),
+                OrderValueWidgetConfig.Snapshot.of(ConfigManager.get().widgets.orderValue)
+            ))
             .preview(() -> new WidgetPreview<>(OrderValueWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.Orders), "default"))
             .viewFactory(OrderValueWidgetView::new)
             .settingsPanel(OrderValueWidgetSettings::create)
             .minSize(WidgetLayoutTokens.panelWidth(90), 32)
             .build();
     }
+
+    private record CacheKey(
+        long data,
+        OrderValueWidgetConfig.Snapshot config
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetView.java
@@ -13,7 +13,6 @@ import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.core.UIComponent;
 import java.util.function.Consumer;
 import net.minecraft.network.chat.Component;
-import org.jetbrains.annotations.Nullable;
 
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.boldLabel;
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.label;
@@ -27,8 +26,6 @@ final class OrderValueWidgetView implements WidgetView<OrderValueWidgetData.Snap
     private final ValueLine sellClaimable = new ValueLine("Sell Offers (Claimable)", false);
     private final ValueLine sellPending = new ValueLine("Sell Offers (Pending)", false);
     private final ValueLine total = new ValueLine("Total Worth", true);
-    private @Nullable OrderValueWidgetData.Snapshot lastData;
-    private @Nullable OrderValueWidgetConfig.Snapshot lastConfig;
 
     OrderValueWidgetView() {
         this.root.allowOverflow(true);
@@ -47,13 +44,6 @@ final class OrderValueWidgetView implements WidgetView<OrderValueWidgetData.Snap
         WidgetSession session,
         Consumer<Void> actions
     ) {
-        var configSnapshot = OrderValueWidgetConfig.Snapshot.of(config);
-        if (data.equals(this.lastData) && configSnapshot.equals(this.lastConfig)) {
-            return;
-        }
-        this.lastData = data;
-        this.lastConfig = configSnapshot;
-
         this.buyLocked.update(data.buyLocked(), BazaarStyles.BUY_ACCENT);
         this.buyItems.update(data.buyItems(), BazaarStyles.BUY_ACCENT);
         this.sellClaimable.update(data.sellClaimable(), BazaarStyles.SELL_ACCENT);

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ordervalue/OrderValueWidgetView.java
@@ -13,6 +13,7 @@ import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.core.UIComponent;
 import java.util.function.Consumer;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
 
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.boldLabel;
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.label;
@@ -26,6 +27,8 @@ final class OrderValueWidgetView implements WidgetView<OrderValueWidgetData.Snap
     private final ValueLine sellClaimable = new ValueLine("Sell Offers (Claimable)", false);
     private final ValueLine sellPending = new ValueLine("Sell Offers (Pending)", false);
     private final ValueLine total = new ValueLine("Total Worth", true);
+    private @Nullable OrderValueWidgetData.Snapshot lastData;
+    private @Nullable OrderValueWidgetConfig.Snapshot lastConfig;
 
     OrderValueWidgetView() {
         this.root.allowOverflow(true);
@@ -44,6 +47,13 @@ final class OrderValueWidgetView implements WidgetView<OrderValueWidgetData.Snap
         WidgetSession session,
         Consumer<Void> actions
     ) {
+        var configSnapshot = OrderValueWidgetConfig.Snapshot.of(config);
+        if (data.equals(this.lastData) && configSnapshot.equals(this.lastConfig)) {
+            return;
+        }
+        this.lastData = data;
+        this.lastConfig = configSnapshot;
+
         this.buyLocked.update(data.buyLocked(), BazaarStyles.BUY_ACCENT);
         this.buyItems.update(data.buyItems(), BazaarStyles.BUY_ACCENT);
         this.sellClaimable.update(data.sellClaimable(), BazaarStyles.SELL_ACCENT);

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
@@ -2,7 +2,6 @@ package com.github.lutzluca.btrbz.core.widgets.presets;
 
 import com.github.lutzluca.btrbz.core.ProductInfoProvider;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
-import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.data.IndexedProduct;
 import com.github.lutzluca.btrbz.data.ProductIdentity;
@@ -37,15 +36,6 @@ public final class OrderPresetsComponent {
     private String cachedClipboard = "";
     private long clipboardReadAt = Long.MIN_VALUE;
 
-    public record State(
-        int maximumVolume,
-        boolean inTransaction,
-        String clipboard,
-        double purse,
-        @Nullable String productId,
-        double pricePerUnit,
-        List<Integer> volumes
-    ) implements WidgetCacheKey {}
 
     public OrderPresetsComponent(BazaarData bazaarData, ProductInfoProvider productInfoProvider) {
         this.bazaarData = bazaarData;
@@ -293,4 +283,14 @@ public final class OrderPresetsComponent {
         record InsufficientCoins(OrderPreset preset) implements Unavailable {}
         record CannotAffordSingleItem(OrderPreset preset, double missingCoins) implements Unavailable {}
     }
+
+    public record State(
+        int maximumVolume,
+        boolean inTransaction,
+        String clipboard,
+        double purse,
+        @Nullable String productId,
+        double pricePerUnit,
+        List<Integer> volumes
+    ) {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
@@ -2,6 +2,7 @@ package com.github.lutzluca.btrbz.core.widgets.presets;
 
 import com.github.lutzluca.btrbz.core.ProductInfoProvider;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.data.BazaarData;
 import com.github.lutzluca.btrbz.data.IndexedProduct;
 import com.github.lutzluca.btrbz.data.ProductIdentity;
@@ -32,6 +33,19 @@ public final class OrderPresetsComponent {
     private int pendingVolume = -1;
     private boolean pendingPreset;
     private boolean inTransaction;
+    private static final long CLIPBOARD_POLL_MILLIS = 250;
+    private String cachedClipboard = "";
+    private long clipboardReadAt = Long.MIN_VALUE;
+
+    public record State(
+        int maximumVolume,
+        boolean inTransaction,
+        String clipboard,
+        double purse,
+        @Nullable String productId,
+        double pricePerUnit,
+        List<Integer> volumes
+    ) implements WidgetCacheKey {}
 
     public OrderPresetsComponent(BazaarData bazaarData, ProductInfoProvider productInfoProvider) {
         this.bazaarData = bazaarData;
@@ -58,27 +72,46 @@ public final class OrderPresetsComponent {
         return this.inTransaction;
     }
 
-    public List<PresetState> currentPresets() {
-        var purse = GameUtils.getPurse();
-        var price = Optional.ofNullable(this.currentProduct())
+    public State currentState() {
+        var product = this.currentProduct();
+        double price = Optional.ofNullable(product)
             .map(ProductIdentity::fromIndex)
             .flatMap(this.bazaarData::highestBuyOrderPrice)
-            .map(value -> value + 0.1);
+            .map(value -> value + 0.1)
+            .orElse(Double.NaN);
+        return new State(
+            this.maximumVolume,
+            this.inTransaction,
+            this.clipboard(),
+            GameUtils.getPurse().orElse(Double.NaN),
+            product == null ? null : product.productId(),
+            price,
+            List.copyOf(ConfigManager.get().widgets.orderPresets.volumes)
+        );
+    }
+
+    public List<PresetState> currentPresets() {
+        return presetsFor(this.currentState());
+    }
+
+    private static List<PresetState> presetsFor(State state) {
+        var price = Double.isNaN(state.pricePerUnit())
+            ? Optional.<Double>empty()
+            : Optional.of(state.pricePerUnit());
         OptionalInt clipboard = OptionalInt.empty();
-        String rawClipboard = Minecraft.getInstance().keyboardHandler.getClipboard();
-        if (!rawClipboard.isBlank()) {
-            clipboard = Utils.parseUsFormattedNumber(rawClipboard)
+        if (!state.clipboard().isBlank()) {
+            clipboard = Utils.parseUsFormattedNumber(state.clipboard())
                 .map(Number::intValue)
-                .filter(value -> value > 0 && value <= this.maximumVolume)
+                .filter(value -> value > 0 && value <= state.maximumVolume())
                 .map(OptionalInt::of)
                 .getOrElse(OptionalInt.empty());
         }
         return resolvePresets(
-            ConfigManager.get().widgets.orderPresets.volumes,
-            this.maximumVolume,
+            state.volumes(),
+            state.maximumVolume(),
             clipboard,
             price,
-            purse
+            Double.isNaN(state.purse()) ? Optional.empty() : Optional.of(state.purse())
         );
     }
 
@@ -200,6 +233,15 @@ public final class OrderPresetsComponent {
 
     private @Nullable IndexedProduct currentProduct() {
         return this.productInfoProvider.getOpenedProduct();
+    }
+
+    private String clipboard() {
+        long now = System.currentTimeMillis();
+        if (now - this.clipboardReadAt >= CLIPBOARD_POLL_MILLIS) {
+            this.cachedClipboard = Minecraft.getInstance().keyboardHandler.getClipboard();
+            this.clipboardReadAt = now;
+        }
+        return this.cachedClipboard;
     }
 
     private Optional<Integer> readMaximumVolume(ItemStack item) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsComponent.java
@@ -34,7 +34,8 @@ public final class OrderPresetsComponent {
     private boolean inTransaction;
     private static final long CLIPBOARD_POLL_MILLIS = 250;
     private String cachedClipboard = "";
-    private long clipboardReadAt = Long.MIN_VALUE;
+    private long clipboardReadAt;
+    private boolean clipboardRead;
 
 
     public OrderPresetsComponent(BazaarData bazaarData, ProductInfoProvider productInfoProvider) {
@@ -227,9 +228,10 @@ public final class OrderPresetsComponent {
 
     private String clipboard() {
         long now = System.currentTimeMillis();
-        if (now - this.clipboardReadAt >= CLIPBOARD_POLL_MILLIS) {
+        if (!this.clipboardRead || now - this.clipboardReadAt >= CLIPBOARD_POLL_MILLIS) {
             this.cachedClipboard = Minecraft.getInstance().keyboardHandler.getClipboard();
             this.clipboardReadAt = now;
+            this.clipboardRead = true;
         }
         return this.cachedClipboard;
     }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/presets/OrderPresetsWidgetDefinition.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.presets;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
@@ -22,6 +23,16 @@ public final class OrderPresetsWidgetDefinition {
             .supports(session -> session.inBazaarMenu(BazaarMenuType.BuyOrderSetupVolume)
                 || session.inSign() && session.previousBazaarMenu(BazaarMenuType.BuyOrderSetupVolume))
             .runtimeData(_ -> data.snapshot())
+            .cacheKey(_ -> {
+                var config = ConfigManager.get().widgets.orderPresets;
+                return new CacheKey(
+                    component.currentState(),
+                    new ConfigSnapshot(
+                        config.contentWidth, config.visibleRows,
+                        config.clipboard, config.showDisabled
+                    )
+                );
+            })
             .preview(() -> new WidgetPreview<>(OrderPresetsWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.BuyOrderSetupVolume), "default"))
             .viewFactory(OrderPresetsWidgetView::new)
             .actionHandler(new OrderPresetsActionHandler(component))
@@ -31,4 +42,13 @@ public final class OrderPresetsWidgetDefinition {
             .minSize(WidgetLayoutTokens.panelWidth(40), 42)
             .build();
     }
+
+    private record ConfigSnapshot(
+        int contentWidth, int visibleRows, boolean clipboard, boolean showDisabled
+    ) {}
+
+    private record CacheKey(
+        OrderPresetsComponent.State state,
+        ConfigSnapshot config
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetData.java
@@ -13,22 +13,48 @@ public final class PriceDifferenceWidgetData {
     private static final int SELL_INSTANTLY_SLOT = 11;
     private final BazaarData market;
 
+    public record StateKey(String productName, double perItem, int quantity) {
+        static StateKey empty() {
+            return new StateKey("", 0, 0);
+        }
+    }
+
     public PriceDifferenceWidgetData(BazaarData market) {
         this.market = market;
     }
 
-    public Snapshot snapshot() {
+    public StateKey stateKey() {
         var info = ScreenInfoHelper.get().getCurrInfo();
-        var productStack = info.getItemStack(PRODUCT_SLOT);
         int quantity = info.getItemStack(SELL_INSTANTLY_SLOT).flatMap(this::listedCount).orElse(0);
-        if (productStack.isEmpty() || quantity <= 0) return empty();
+        if (quantity <= 0) {
+            return StateKey.empty();
+        }
+
+        var productStack = info.getItemStack(PRODUCT_SLOT);
+        if (productStack.isEmpty()) {
+            return StateKey.empty();
+        }
+
         var stack = productStack.orElseThrow();
-        var product = this.market.resolveProduct(stack);
-        var spread = this.market.productSpread(product);
-        if (spread.isEmpty()) return empty();
-        return new Snapshot(
-            stack.getHoverName().getString(), Optional.of(stack), spread.get(), quantity
-        );
+        var spread = this.market.productSpread(this.market.resolveProduct(stack));
+        if (spread.isEmpty()) {
+            return StateKey.empty();
+        }
+
+        return new StateKey(stack.getHoverName().getString(), spread.get(), quantity);
+    }
+
+    public Snapshot snapshot() {
+        return this.snapshotFor(this.stateKey());
+    }
+
+    public Snapshot snapshotFor(StateKey key) {
+        if (key.quantity() <= 0) {
+            return empty();
+        }
+        return ScreenInfoHelper.get().getCurrInfo().getItemStack(PRODUCT_SLOT)
+            .map(stack -> new Snapshot(key.productName(), Optional.of(stack), key.perItem(), key.quantity()))
+            .orElseGet(PriceDifferenceWidgetData::empty);
     }
 
     public static Snapshot preview() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDefinition.java
@@ -8,6 +8,7 @@ import com.github.lutzluca.btrbz.core.widgets.session.WidgetPreviewSessions;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetLayoutTokens;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.data.BazaarData;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import net.minecraft.resources.Identifier;
 
 public final class PriceDifferenceWidgetDefinition {
@@ -23,10 +24,19 @@ public final class PriceDifferenceWidgetDefinition {
             .supports(session -> session.inBazaarMenu(BazaarMenuType.Item))
             .visibility((data, _, _) -> data.quantity() > 0)
             .runtimeData(_ -> provider.snapshot())
+            .cacheKey(_ -> new CacheKey(
+                provider.stateKey(),
+                ConfigManager.get().widgets.priceDiff.contentWidth
+            ))
             .preview(() -> new WidgetPreview<>(PriceDifferenceWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.Item), "default"))
             .viewFactory(PriceDifferenceWidgetView::new)
             .settingsPanel(PriceDifferenceWidgetSettings::create)
             .minSize(WidgetLayoutTokens.panelWidth(80), 36)
             .build();
     }
+
+    private record CacheKey(
+        PriceDifferenceWidgetData.StateKey state,
+        int contentWidth
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.HashMap;
 import lombok.extern.slf4j.Slf4j;
 
 /** Retained runtime/preview host for the single ordered widget registry. */
@@ -45,6 +46,7 @@ public final class WidgetHost {
     private final @Nullable Map<WidgetId, WidgetPreview<?>> capturedPreviews;
     private final @Nullable Map<WidgetId, Double> scrollOffsets;
     private final Map<WidgetId, MountedWidget> mounted = new LinkedHashMap<>();
+    private final Map<WidgetId, PrepareCache> prepareCache = new HashMap<>();
     private final Set<Integer> capturedMouseButtons = new HashSet<>();
     private OwoUIAdapter<WidgetCanvasComponent> adapter;
     private List<RuntimeWidgetHit> runtimeWidgetHits = List.of();
@@ -216,11 +218,27 @@ public final class WidgetHost {
         try {
             WidgetPreview preview = this.runtime ? null : this.preview(definition);
             WidgetSession session = this.runtime ? runtimeSession : preview.session();
-            Object data = this.runtime ? definition.getRuntimeData().apply(session) : preview.data();
-            Object config = definition.config();
             var mountedWidget = this.mounted.computeIfAbsent(
                 definition.getId(), _ -> this.mount(definition)
             );
+            PrepareKey prepareKey = null;
+            if (this.runtime && session != null) {
+                var widgetKey = definition.cacheKey(session);
+                if (widgetKey != null) {
+                    prepareKey = new PrepareKey(
+                        widgetKey, session.id(),
+                        screenCanvas.width(), screenCanvas.height(), options
+                    );
+                    var cached = this.prepareCache.get(definition.getId());
+                    if (cached != null && prepareKey.equals(cached.key())) {
+                        return cached.result();
+                    }
+                }
+            }
+
+            Object data = this.runtime ? definition.getRuntimeData().apply(session) : preview.data();
+            Object config = definition.config();
+
             Consumer actions = this.runtime
                 ? action -> this.dispatch(definition, action, session)
                 : _ -> {};
@@ -237,7 +255,11 @@ public final class WidgetHost {
                     mountedWidget.slot().localBounds(), 1, 1, 1,
                     options.isSelected(definition), options.drawManagementOverlay(), false
                 );
-                return new PreparedWidget(mountedWidget, null, anchorCanvas);
+                var prepared = new PreparedWidget(mountedWidget, null, anchorCanvas);
+                if (prepareKey != null) {
+                    this.prepareCache.put(definition.getId(), new PrepareCache(prepareKey, prepared));
+                }
+                return prepared;
             }
 
             double minimumScale = WidgetScaleResolver.MIN_SCALE;
@@ -283,7 +305,11 @@ public final class WidgetHost {
                 ),
                 logicalWidth, logicalHeight, scale
             );
-            return new PreparedWidget(mountedWidget, result, anchorCanvas);
+            var prepared = new PreparedWidget(mountedWidget, result, anchorCanvas);
+            if (prepareKey != null) {
+                this.prepareCache.put(definition.getId(), new PrepareCache(prepareKey, prepared));
+            }
+            return prepared;
         } catch (Exception exception) {
             log.warn("Widget {} failed during retained update", definition.getId(), exception);
             this.detach(definition.getId());
@@ -330,6 +356,7 @@ public final class WidgetHost {
     private void detach(WidgetId id) {
         var removed = this.mounted.remove(id);
         if (removed == null) return;
+        this.prepareCache.remove(id);
         if (this.scrollOffsets != null && removed.view() instanceof ScrollOffsetView scrollView) {
             this.scrollOffsets.put(id, scrollView.scrollOffset());
         }
@@ -378,6 +405,14 @@ public final class WidgetHost {
         io.wispforest.owo.ui.core.UIComponent component,
         WidgetSlotComponent slot,
         WidgetRenderSurface surface
+    ) {}
+    private record PrepareCache(PrepareKey key, PreparedWidget result) {}
+    private record PrepareKey(
+        Object widgetKey,
+        long sessionId,
+        int canvasWidth,
+        int canvasHeight,
+        WidgetHostOptions options
     ) {}
     private record PreparedWidget(
         MountedWidget mounted,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -1,5 +1,6 @@
 package com.github.lutzluca.btrbz.core.widgets.runtime;
 
+import com.github.lutzluca.btrbz.core.widgets.*;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetSessionProvider;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetCanvasComponent;
@@ -10,11 +11,6 @@ import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetBounds;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetPlacement;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetScaleResolver;
-import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
-import com.github.lutzluca.btrbz.core.widgets.WidgetId;
-import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
-import com.github.lutzluca.btrbz.core.widgets.WidgetView;
-import com.github.lutzluca.btrbz.core.widgets.ScrollOffsetView;
 import com.github.lutzluca.btrbz.core.widgets.config.WidgetStateStore;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.wispforest.owo.ui.core.OwoUIAdapter;
@@ -408,7 +404,7 @@ public final class WidgetHost {
     ) {}
     private record PrepareCache(PrepareKey key, PreparedWidget result) {}
     private record PrepareKey(
-        Object widgetKey,
+        WidgetCacheKey widgetKey,
         long sessionId,
         int canvasWidth,
         int canvasHeight,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -223,6 +223,7 @@ public final class WidgetHost {
                 if (widgetKey != null) {
                     prepareKey = new PrepareKey(
                         widgetKey, session.id(),
+                        screenCanvas.x(), screenCanvas.y(),
                         screenCanvas.width(), screenCanvas.height(), options,
                         this.stateStore.frameRevision()
                     );
@@ -407,6 +408,8 @@ public final class WidgetHost {
     private record PrepareKey(
         WidgetCacheKey widgetKey,
         long sessionId,
+        int canvasX,
+        int canvasY,
         int canvasWidth,
         int canvasHeight,
         WidgetHostOptions options,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -223,7 +223,8 @@ public final class WidgetHost {
                 if (widgetKey != null) {
                     prepareKey = new PrepareKey(
                         widgetKey, session.id(),
-                        screenCanvas.width(), screenCanvas.height(), options
+                        screenCanvas.width(), screenCanvas.height(), options,
+                        this.stateStore.frameRevision()
                     );
                     var cached = this.prepareCache.get(definition.getId());
                     if (cached != null && prepareKey.equals(cached.key())) {
@@ -408,7 +409,8 @@ public final class WidgetHost {
         long sessionId,
         int canvasWidth,
         int canvasHeight,
-        WidgetHostOptions options
+        WidgetHostOptions options,
+        long frameRevision
     ) {}
     private record PreparedWidget(
         MountedWidget mounted,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHostOptions.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHostOptions.java
@@ -14,12 +14,17 @@ public record WidgetHostOptions(
     @Nullable Set<WidgetId> renderedWidgets,
     Map<WidgetId, String> placementProfiles
 ) {
+    private static final WidgetHostOptions RUNTIME_WITH_TOOLTIPS =
+        new WidgetHostOptions(null, false, true, null, Map.of());
+    private static final WidgetHostOptions RUNTIME_NO_TOOLTIPS =
+        new WidgetHostOptions(null, false, false, null, Map.of());
+
     public WidgetHostOptions {
         placementProfiles = Map.copyOf(placementProfiles);
     }
 
     public static WidgetHostOptions runtime(boolean allowTooltips) {
-        return new WidgetHostOptions(null, false, allowTooltips, null, Map.of());
+        return allowTooltips ? RUNTIME_WITH_TOOLTIPS : RUNTIME_NO_TOOLTIPS;
     }
 
     public static WidgetHostOptions management(

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/session/DefaultWidgetSessionProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/session/DefaultWidgetSessionProvider.java
@@ -26,6 +26,8 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
     private final TrackedOrderManager trackedOrders;
     private @Nullable SemanticKey previousKey;
     private long semanticSessionId;
+    private @Nullable SessionKey cachedKey;
+    private @Nullable WidgetSession cachedSession;
 
     public DefaultWidgetSessionProvider(
         BazaarData market,
@@ -42,6 +44,16 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
     @Override
     public WidgetSession current(@Nullable Screen screen) {
         var helper = ScreenInfoHelper.get();
+        var sessionKey = new SessionKey(
+            screen,
+            helper.screenTransitionVersion(),
+            helper.inventoryVersion()
+        );
+        var cached = this.cachedSession;
+        if (cached != null && sessionKey.equals(this.cachedKey)) {
+            return cached;
+        }
+
         var current = helper.getCurrInfo();
         var previous = helper.getPrevInfo();
         boolean hud = screen == null;
@@ -83,7 +95,7 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
             this.semanticSessionId++;
         }
 
-        return new WidgetSession(
+        var session = new WidgetSession(
             this.semanticSessionId,
             hud,
             sign,
@@ -94,6 +106,9 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
             side,
             this.trackedOrders.displayRevision()
         );
+        this.cachedKey = sessionKey;
+        this.cachedSession = session;
+        return session;
     }
 
     private WidgetProductContext context(ProductIdentity identity, Optional<ItemStack> observedStack) {
@@ -122,4 +137,6 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
         Optional<String> productId,
         Optional<OrderType> side
     ) {}
+
+    private record SessionKey(@Nullable Screen screen, long transition, long inventory) {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/session/DefaultWidgetSessionProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/session/DefaultWidgetSessionProvider.java
@@ -47,7 +47,8 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
         var sessionKey = new SessionKey(
             screen,
             helper.screenTransitionVersion(),
-            helper.inventoryVersion()
+            helper.inventoryVersion(),
+            this.trackedOrders.displayRevision()
         );
         var cached = this.cachedSession;
         if (cached != null && sessionKey.equals(this.cachedKey)) {
@@ -138,5 +139,5 @@ public final class DefaultWidgetSessionProvider implements WidgetSessionProvider
         Optional<OrderType> side
     ) {}
 
-    private record SessionKey(@Nullable Screen screen, long transition, long inventory) {}
+    private record SessionKey(@Nullable Screen screen, long transition, long inventory, long trackedRevision) {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
@@ -46,6 +46,12 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
     private boolean interactive;
     private Consumer<TrackedOrdersAction> actions;
 
+    private @Nullable BazaarWidgetViewData.Order lastOrder;
+    private @Nullable TrackedOrdersWidgetConfig.Snapshot lastOptions;
+    private int lastIndex = -1;
+    private boolean lastInteractive;
+    private boolean initialized;
+
     BazaarTrackedOrderRowComponent(
         BazaarTrackedOrderListComponent list,
         BazaarWidgetViewData.Order order,
@@ -71,29 +77,51 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
         boolean interactive,
         Consumer<TrackedOrdersAction> actions
     ) {
+        this.actions = actions;
         this.order = order;
         this.options = options;
+
+        var optionsSnapshot = TrackedOrdersWidgetConfig.Snapshot.of(options);
+        if (this.initialized
+            && order == this.lastOrder
+            && optionsSnapshot.equals(this.lastOptions)
+            && index == this.lastIndex
+            && interactive == this.lastInteractive) {
+            return;
+        }
+
+        boolean layoutChanged = this.lastOptions == null || this.lastOptions.layout() != optionsSnapshot.layout();
+
         this.productName = order.formattedItemName(false);
         this.index = index;
         this.reorderable = interactive && options.sort == TrackedOrdersWidgetConfig.TrackedSort.Manual;
         this.interactive = interactive;
-        var itemStack = order.itemStack();
-        this.actions = actions;
+
         int iconSize = options.layout == TrackedOrdersWidgetConfig.TrackedLayout.Compact
             ? COMPACT_ICON_SIZE : STANDARD_ICON_SIZE;
+        var itemStack = order.itemStack();
         if (itemStack.isPresent()) {
             if (this.item == null) {
                 this.item = BazaarUi.item(itemStack.orElseThrow(), iconSize);
             } else {
                 this.item.stack(itemStack.orElseThrow());
-                this.item.sizing(Sizing.fixed(iconSize), Sizing.fixed(iconSize));
+                if (layoutChanged) {
+                    this.item.sizing(Sizing.fixed(iconSize), Sizing.fixed(iconSize));
+                }
             }
         }
-        this.verticalSizing(Sizing.fixed(
-            options.layout == TrackedOrdersWidgetConfig.TrackedLayout.Compact ? COMPACT_HEIGHT : STANDARD_HEIGHT
-        ));
+        if (layoutChanged) {
+            this.verticalSizing(Sizing.fixed(options.layout == TrackedOrdersWidgetConfig.TrackedLayout.Compact ? COMPACT_HEIGHT : STANDARD_HEIGHT));
+        }
+
         this.tooltip(interactive ? WidgetTooltips.wrapped(tooltip) : List.of());
         this.updateLayout();
+
+        this.initialized = true;
+        this.lastOrder = order;
+        this.lastOptions = optionsSnapshot;
+        this.lastIndex = index;
+        this.lastInteractive = interactive;
     }
 
     @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
@@ -114,16 +114,17 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
         int iconSize = options.layout == TrackedOrdersWidgetConfig.TrackedLayout.Compact
             ? COMPACT_ICON_SIZE : STANDARD_ICON_SIZE;
         var itemStack = order.itemStack();
-        if (itemStack.isPresent()) {
-            if (this.item == null) {
-                this.item = BazaarUi.item(itemStack.orElseThrow(), iconSize);
-            } else {
-                this.item.stack(itemStack.orElseThrow());
-                if (layoutChanged) {
-                    this.item.sizing(Sizing.fixed(iconSize), Sizing.fixed(iconSize));
-                }
+        if (itemStack.isEmpty()) {
+            this.item = null;
+        } else if (this.item == null) {
+            this.item = BazaarUi.item(itemStack.orElseThrow(), iconSize);
+        } else {
+            this.item.stack(itemStack.orElseThrow());
+            if (layoutChanged) {
+                this.item.sizing(Sizing.fixed(iconSize), Sizing.fixed(iconSize));
             }
         }
+
         if (layoutChanged) {
             this.verticalSizing(Sizing.fixed(options.layout == TrackedOrdersWidgetConfig.TrackedLayout.Compact ? COMPACT_HEIGHT : STANDARD_HEIGHT));
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/BazaarTrackedOrderRowComponent.java
@@ -18,6 +18,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -51,6 +52,17 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
     private int lastIndex = -1;
     private boolean lastInteractive;
     private boolean initialized;
+
+    private @Nullable DrawLayout drawLayout;
+    private int drawLayoutWidth = -1;
+
+    private record DrawLayout(
+        Component side, int sideX,
+        Component status, int statusX,
+        FormattedCharSequence productText,
+        @Nullable FormattedCharSequence identityText,
+        @Nullable Component marketText, int marketX
+    ) {}
 
     BazaarTrackedOrderRowComponent(
         BazaarTrackedOrderListComponent list,
@@ -89,6 +101,8 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
             && interactive == this.lastInteractive) {
             return;
         }
+
+        this.drawLayout = null;
 
         boolean layoutChanged = this.lastOptions == null || this.lastOptions.layout() != optionsSnapshot.layout();
 
@@ -211,45 +225,100 @@ final class BazaarTrackedOrderRowComponent extends BaseParentUIComponent {
     }
 
     private void drawStandard(OwoUIGraphics graphics) {
+        if (this.drawLayout == null || this.drawLayoutWidth != this.width) {
+            this.drawLayout = this.computeStandardLayout();
+            this.drawLayoutWidth = this.width;
+        }
+        var layout = this.drawLayout;
         var font = Minecraft.getInstance().font;
+
         int x = this.x + WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
-        if (this.item != null) x += STANDARD_ICON_SIZE + TEXT_GAP;
-        int right = this.x + this.width - WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
-        var side = Component.literal(this.order.side().label()).withStyle(ChatFormatting.BOLD);
-        int sideX = right - font.width(side);
-        var status = Component.literal(this.order.status().label()).withStyle(ChatFormatting.BOLD);
-        int statusX = sideX - TEXT_GAP - font.width(status);
-        graphics.text(font, ellipsize(this.productName, Math.max(0, statusX - TEXT_GAP - x)),
-            x, this.y + 1, BazaarStyles.PRIMARY_TEXT, false);
-        graphics.text(font, status, statusX, this.y + 1, this.order.status().color(), false);
-        graphics.text(font, side, sideX, this.y + 1, this.order.side().accentColor(), false);
+        if (this.item != null) {
+            x += STANDARD_ICON_SIZE + TEXT_GAP;
+        }
+
+        graphics.text(font, layout.productText(), x, this.y + 1, BazaarStyles.PRIMARY_TEXT, false);
+        graphics.text(font, layout.status(), this.x + layout.statusX(), this.y + 1,
+            this.order.status().color(), false);
+        graphics.text(font, layout.side(), this.x + layout.sideX(), this.y + 1,
+            this.order.side().accentColor(), false);
 
         int secondY = this.y + 1 + font.lineHeight + WidgetLayoutTokens.LINE_GAP;
-        String identity = BazaarOrderText.orderIdentity(this.order);
-        String marketText = this.firstFittingMarketText(Math.max(0,
-            right - x - font.width(identity) - TEXT_GAP));
-        int marketX = marketText.isBlank() ? right : right - font.width(marketText);
-        graphics.text(font, ellipsize(Component.literal(identity), Math.max(0, marketX - TEXT_GAP - x)),
-            x, secondY, BazaarStyles.SECONDARY_TEXT, false);
-        if (!marketText.isBlank()) {
-            graphics.text(font, Component.literal(marketText), marketX, secondY, BazaarStyles.SECONDARY_TEXT, false);
+        if (layout.identityText() != null) {
+            graphics.text(font, layout.identityText(), x, secondY, BazaarStyles.SECONDARY_TEXT, false);
+        }
+        if (layout.marketText() != null) {
+            graphics.text(font, layout.marketText(), this.x + layout.marketX(), secondY,
+                BazaarStyles.SECONDARY_TEXT, false);
         }
     }
 
-    private void drawCompact(OwoUIGraphics graphics) {
+    private DrawLayout computeStandardLayout() {
         var font = Minecraft.getInstance().font;
-        int textY = this.y + Math.max(0, (this.height - COMPACT_PROGRESS_HEIGHT - font.lineHeight) / 2);
-        int x = this.x + WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
-        if (this.item != null) x += COMPACT_ICON_SIZE + TEXT_GAP;
-        int right = this.x + this.width - WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+        int x = WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+        if (this.item != null) {
+            x += STANDARD_ICON_SIZE + TEXT_GAP;
+        }
+        int right = this.width - WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+
         var side = Component.literal(this.order.side().label()).withStyle(ChatFormatting.BOLD);
         int sideX = right - font.width(side);
         var status = Component.literal(this.order.status().label()).withStyle(ChatFormatting.BOLD);
         int statusX = sideX - TEXT_GAP - font.width(status);
-        graphics.text(font, ellipsize(this.productName, Math.max(0, statusX - TEXT_GAP - x)),
-            x, textY, BazaarStyles.PRIMARY_TEXT, false);
-        graphics.text(font, status, statusX, textY, this.order.status().color(), false);
-        graphics.text(font, side, sideX, textY, this.order.side().accentColor(), false);
+        var productText = ellipsize(this.productName, Math.max(0, statusX - TEXT_GAP - x));
+
+        String identity = BazaarOrderText.orderIdentity(this.order);
+        String market = this.firstFittingMarketText(
+            Math.max(0, right - x - font.width(identity) - TEXT_GAP)
+        );
+        int marketX = market.isBlank() ? right : right - font.width(market);
+        var identityText = ellipsize(Component.literal(identity), Math.max(0, marketX - TEXT_GAP - x));
+
+        return new DrawLayout(
+            side, sideX, status, statusX, productText,
+            identityText,
+            market.isBlank() ? null : Component.literal(market),
+            marketX
+        );
+    }
+
+
+    private void drawCompact(OwoUIGraphics graphics) {
+        if (this.drawLayout == null || this.drawLayoutWidth != this.width) {
+            this.drawLayout = this.computeCompactLayout();
+            this.drawLayoutWidth = this.width;
+        }
+        var layout = this.drawLayout;
+        var font = Minecraft.getInstance().font;
+
+        int textY = this.y + Math.max(0, (this.height - COMPACT_PROGRESS_HEIGHT - font.lineHeight) / 2);
+        int x = this.x + WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+        if (this.item != null) {
+            x += COMPACT_ICON_SIZE + TEXT_GAP;
+        }
+
+        graphics.text(font, layout.productText(), x, textY, BazaarStyles.PRIMARY_TEXT, false);
+        graphics.text(font, layout.status(), this.x + layout.statusX(), textY,
+            this.order.status().color(), false);
+        graphics.text(font, layout.side(), this.x + layout.sideX(), textY,
+            this.order.side().accentColor(), false);
+    }
+
+    private DrawLayout computeCompactLayout() {
+        var font = Minecraft.getInstance().font;
+        int x = WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+        if (this.item != null) {
+            x += COMPACT_ICON_SIZE + TEXT_GAP;
+        }
+        int right = this.width - WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+
+        var side = Component.literal(this.order.side().label()).withStyle(ChatFormatting.BOLD);
+        int sideX = right - font.width(side);
+        var status = Component.literal(this.order.status().label()).withStyle(ChatFormatting.BOLD);
+        int statusX = sideX - TEXT_GAP - font.width(status);
+        var productText = ellipsize(this.productName, Math.max(0, statusX - TEXT_GAP - x));
+
+        return new DrawLayout(side, sideX, status, statusX, productText, null, null, 0);
     }
 
     private String firstFittingMarketText(int availableWidth) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetConfig.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetConfig.java
@@ -12,6 +12,13 @@ public final class TrackedOrdersWidgetConfig {
     public int visibleRows = 5;
     public TrackedLayout layout = TrackedLayout.Standard;
     public TrackedSort sort = TrackedSort.Manual;
+
+    public record Snapshot(int contentWidth,int visibleRows, TrackedLayout layout, TrackedSort sort) {
+        public static Snapshot of(TrackedOrdersWidgetConfig config) {
+            return new Snapshot(config.contentWidth, config.visibleRows, config.layout, config.sort);
+        }
+    }
+
     public static void resetPreferences(TrackedOrdersWidgetConfig current, TrackedOrdersWidgetConfig defaults) {
         current.contentWidth = defaults.contentWidth;
         current.visibleRows = defaults.visibleRows;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetDefinition.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.trackedorders;
 
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
+import com.github.lutzluca.btrbz.core.widgets.WidgetCacheKey;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetPreview;
@@ -26,6 +27,10 @@ public final class TrackedOrdersWidgetDefinition {
             .supports(WidgetSession::inBazaarContainer)
             .visibility((data, _, _) -> !data.orders().isEmpty())
             .runtimeData(_ -> provider.snapshot())
+            .cacheKey(_ -> new CacheKey(
+                provider.snapshotKey(),
+                TrackedOrdersWidgetConfig.Snapshot.of(ConfigManager.get().widgets.trackedOrders)
+            ))
             .preview(() -> new WidgetPreview<>(OrdersWidgetData.preview(), WidgetPreviewSessions.container(BazaarMenuType.Item), "default"))
             .viewFactory(TrackedOrdersWidgetView::new)
             .actionHandler(new TrackedOrdersActionHandler(trackedOrders))
@@ -33,4 +38,9 @@ public final class TrackedOrdersWidgetDefinition {
             .minSize(WidgetLayoutTokens.panelWidth(200), 16)
             .build();
     }
+
+    private record CacheKey(
+        OrdersWidgetData.SnapshotKey data,
+        TrackedOrdersWidgetConfig.Snapshot config
+    ) implements WidgetCacheKey {}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetView.java
@@ -12,7 +12,6 @@ import io.wispforest.owo.ui.container.UIContainers;
 import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.core.UIComponent;
 import io.wispforest.owo.ui.core.VerticalAlignment;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -26,10 +25,6 @@ final class TrackedOrdersWidgetView implements
     private final FlowLayout root = UIContainers.verticalFlow(Sizing.fixed(1), Sizing.content());
     private final LabelComponent status = label("", BazaarStyles.MUTED_TEXT);
     private final BazaarTrackedOrderListComponent list = new BazaarTrackedOrderListComponent();
-
-    private @Nullable BazaarWidgetViewData.OrdersData lastData;
-    private @Nullable TrackedOrdersWidgetConfig.Snapshot lastConfig;
-    private long lastSessionId = Long.MIN_VALUE;
 
     TrackedOrdersWidgetView() {
         this.root.allowOverflow(true);
@@ -66,14 +61,6 @@ final class TrackedOrdersWidgetView implements
         WidgetSession session,
         Consumer<TrackedOrdersAction> actions
     ) {
-        var configSnapshot = TrackedOrdersWidgetConfig.Snapshot.of(config);
-        if (data == this.lastData && configSnapshot.equals(this.lastConfig) && session.id() == this.lastSessionId) {
-            return;
-        }
-        this.lastData = data;
-        this.lastConfig = configSnapshot;
-        this.lastSessionId = session.id();
-
         var sorted = TrackedOrdersWidget.sortedOrders(data.orders(), config.sort);
         this.root.horizontalSizing(Sizing.fixed(config.contentWidth));
         this.status.text(literal(

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/trackedorders/TrackedOrdersWidgetView.java
@@ -12,10 +12,13 @@ import io.wispforest.owo.ui.container.UIContainers;
 import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.core.UIComponent;
 import io.wispforest.owo.ui.core.VerticalAlignment;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.function.Consumer;
 
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.label;
 import static com.github.lutzluca.btrbz.core.widgets.ui.BazaarUi.spacer;
+import static net.minecraft.network.chat.Component.literal;
 
 final class TrackedOrdersWidgetView implements
     WidgetView<BazaarWidgetViewData.OrdersData, TrackedOrdersWidgetConfig, TrackedOrdersAction>,
@@ -23,6 +26,10 @@ final class TrackedOrdersWidgetView implements
     private final FlowLayout root = UIContainers.verticalFlow(Sizing.fixed(1), Sizing.content());
     private final LabelComponent status = label("", BazaarStyles.MUTED_TEXT);
     private final BazaarTrackedOrderListComponent list = new BazaarTrackedOrderListComponent();
+
+    private @Nullable BazaarWidgetViewData.OrdersData lastData;
+    private @Nullable TrackedOrdersWidgetConfig.Snapshot lastConfig;
+    private long lastSessionId = Long.MIN_VALUE;
 
     TrackedOrdersWidgetView() {
         this.root.allowOverflow(true);
@@ -59,9 +66,17 @@ final class TrackedOrdersWidgetView implements
         WidgetSession session,
         Consumer<TrackedOrdersAction> actions
     ) {
+        var configSnapshot = TrackedOrdersWidgetConfig.Snapshot.of(config);
+        if (data == this.lastData && configSnapshot.equals(this.lastConfig) && session.id() == this.lastSessionId) {
+            return;
+        }
+        this.lastData = data;
+        this.lastConfig = configSnapshot;
+        this.lastSessionId = session.id();
+
         var sorted = TrackedOrdersWidget.sortedOrders(data.orders(), config.sort);
         this.root.horizontalSizing(Sizing.fixed(config.contentWidth));
-        this.status.text(net.minecraft.network.chat.Component.literal(
+        this.status.text(literal(
             TrackedOrdersWidget.headerStatus(data, sorted.size())
         ));
         this.list.update(sorted, config, true, BazaarWidgetViewData.Order::tooltipLines, actions);

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ui/BazaarOrderRowComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ui/BazaarOrderRowComponent.java
@@ -7,6 +7,8 @@ import io.wispforest.owo.ui.core.Sizing;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -19,6 +21,10 @@ public final class BazaarOrderRowComponent extends BaseUIComponent {
     private boolean hoverable;
     private boolean reserveScrollbarSpace;
     private boolean hoverSuppressed;
+
+    private @Nullable BazaarRow.Appearance lastAppearance;
+    private @Nullable DrawLayout drawLayout;
+    private int drawLayoutWidth = -1;
 
     BazaarOrderRowComponent(
         BazaarRow row,
@@ -34,11 +40,17 @@ public final class BazaarOrderRowComponent extends BaseUIComponent {
     }
 
     void update(BazaarRow row, boolean hoverable, int height, boolean reserveScrollbarSpace) {
+        var appearance = row.appearance();
+        boolean changed = !appearance.equals(this.lastAppearance) || this.reserveScrollbarSpace != reserveScrollbarSpace;
         this.row = row;
         this.hoverable = hoverable;
         this.reserveScrollbarSpace = reserveScrollbarSpace;
         this.verticalSizing(Sizing.fixed(height));
-        this.tooltip(WidgetTooltips.wrapped(row.tooltip()));
+        if (changed) {
+            this.lastAppearance = appearance;
+            this.drawLayout = null;
+            this.tooltip(WidgetTooltips.wrapped(row.tooltip()));
+        }
     }
 
     @Override public boolean canFocus(FocusSource source) {
@@ -68,22 +80,45 @@ public final class BazaarOrderRowComponent extends BaseUIComponent {
         boolean hovered = this.hoverable && !this.hoverSuppressed && this.isInBoundingBox(mouseX, mouseY);
         if (hovered) graphics.fill(this.x, this.y, this.x + this.width, this.y + this.height, BazaarStyles.ROW_HOVER);
 
+        if (this.drawLayout == null || this.drawLayoutWidth != this.width) {
+            this.drawLayout = this.computeDrawLayout();
+            this.drawLayoutWidth = this.width;
+        }
+        var layout = this.drawLayout;
         var font = Minecraft.getInstance().font;
         int y = this.y + Math.max(0, (this.height - font.lineHeight) / 2);
-        int x = this.x + WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
-        if (this.row.statusColor() != 0) {
+
+        if (layout.dotX() >= 0) {
             int dot = 4;
-            graphics.fill(x, this.y + (this.height - dot) / 2, x + dot, this.y + (this.height + dot) / 2, this.row.statusColor());
-            x += dot + 4;
+            int dotScreenX = this.x + layout.dotX();
+            graphics.fill(dotScreenX, this.y + (this.height - dot) / 2,
+                dotScreenX + dot, this.y + (this.height + dot) / 2, this.row.statusColor());
+        }
+
+        graphics.text(font, layout.prefix(), this.x + layout.prefixX(), y, this.row.prefixColor(), false);
+        graphics.text(font, layout.text(), this.x + layout.textX(), y, BazaarStyles.SECONDARY_TEXT, false);
+        if (layout.rightText() != null) {
+            graphics.text(font, layout.rightText(), this.x + layout.rightX(), y, this.row.rightColor(), false);
+        }
+    }
+
+    private DrawLayout computeDrawLayout() {
+        var font = Minecraft.getInstance().font;
+        int x = WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
+        int dotX = -1;
+        if (this.row.statusColor() != 0) {
+            dotX = x;
+            x += 4 + 4;
         }
 
         int trailingInset = WidgetLayoutTokens.ROW_HORIZONTAL_PADDING;
         if (this.reserveScrollbarSpace) {
             trailingInset += WidgetLayoutTokens.SCROLLBAR_THICKNESS + WidgetLayoutTokens.SCROLLBAR_CONTENT_GAP;
         }
-        int rowEnd = this.x + this.width - trailingInset;
+        int rowEnd = this.width - trailingInset;
         var rightText = Component.literal(this.row.rightText());
         var prefix = Component.literal(this.row.prefix());
+        boolean blankRight = this.row.rightText().isBlank();
 
         if (this.row.preservePrefix()) {
             var widths = priorityWidths(
@@ -91,54 +126,35 @@ public final class BazaarOrderRowComponent extends BaseUIComponent {
                 font.width(prefix),
                 font.width(rightText)
             );
-            graphics.text(font, prefix, x, y, this.row.prefixColor(), false);
+            int prefixX = x;
             x += widths.prefixWidth();
-            int rightWidth = this.row.rightText().isBlank() ? 0 : widths.rightWidth();
+            int rightWidth = blankRight ? 0 : widths.rightWidth();
             int textLimit = rowEnd - rightWidth - (rightWidth == 0 ? 0 : 3);
-            graphics.text(
-                font,
-                ellipsize(Component.literal(this.row.text()), Math.max(0, textLimit - x)),
-                x,
-                y,
-                BazaarStyles.SECONDARY_TEXT,
-                false
+            return new DrawLayout(
+                prefix.getVisualOrderText(), prefixX,
+                ellipsize(Component.literal(this.row.text()), Math.max(0, textLimit - x)), x,
+                rightWidth > 0 ? ellipsize(rightText, rightWidth) : null,
+                rowEnd - rightWidth,
+                dotX
             );
-            if (rightWidth > 0) {
-                graphics.text(
-                    font,
-                    ellipsize(rightText, rightWidth),
-                    rowEnd - rightWidth,
-                    y,
-                    this.row.rightColor(),
-                    false
-                );
-            }
-            return;
         }
 
-        int rightWidth = this.row.rightText().isBlank()
+        int rightWidth = blankRight
             ? 0
             : Math.min(font.width(rightText), Math.max(0, rowEnd - x - MINIMUM_LEFT_WIDTH - 3));
         int rightX = rowEnd - rightWidth;
-        int leftLimit = this.row.rightText().isBlank()
-            ? rowEnd
-            : rightX - 3;
+        int leftLimit = blankRight ? rowEnd : rightX - 3;
         int prefixWidth = Math.max(0, leftLimit - x);
-        graphics.text(font, ellipsize(prefix, prefixWidth), x, y, this.row.prefixColor(), false);
+        int prefixX = x;
+        var prefixSequence = ellipsize(prefix, prefixWidth);
         x += Math.min(font.width(prefix), prefixWidth);
         int textWidth = Math.max(0, leftLimit - x);
-        graphics.text(
-            font,
-            ellipsize(Component.literal(this.row.text()), textWidth),
-            x,
-            y,
-            BazaarStyles.SECONDARY_TEXT,
-            false
+        return new DrawLayout(
+            prefixSequence, prefixX,
+            ellipsize(Component.literal(this.row.text()), textWidth), x,
+            blankRight ? null : ellipsize(rightText, rightWidth), rightX,
+            dotX
         );
-
-        if (!this.row.rightText().isBlank()) {
-            graphics.text(font, ellipsize(rightText, rightWidth), rightX, y, this.row.rightColor(), false);
-        }
     }
 
     public static PriorityWidths priorityWidths(int availableWidth, int prefixWidth, int rightWidth) {
@@ -148,11 +164,33 @@ public final class BazaarOrderRowComponent extends BaseUIComponent {
         return new PriorityWidths(safePrefix, Math.min(Math.max(0, rightWidth), metadataSpace));
     }
 
+    private record DrawLayout(
+        FormattedCharSequence prefix, int prefixX,
+        FormattedCharSequence text, int textX,
+        @Nullable FormattedCharSequence rightText, int rightX,
+        int dotX
+    ) {}
+
     public record PriorityWidths(int prefixWidth, int rightWidth) {}
 
     public record BazaarRow(String id, String prefix, int prefixColor, String text, String rightText, int rightColor,
                        int statusColor, List<Component> tooltip, Consumer<Boolean> clickAction,
                        boolean preservePrefix, int backgroundColor) {
+
+        public Appearance appearance() {
+            return new Appearance(
+                this.id, this.prefix, this.prefixColor, this.text, this.rightText,
+                this.rightColor, this.statusColor, this.tooltip,
+                this.preservePrefix, this.backgroundColor
+            );
+        }
+
+        public record Appearance(
+            String id, String prefix, int prefixColor, String text, String rightText,
+            int rightColor, int statusColor, List<Component> tooltip,
+            boolean preservePrefix, int backgroundColor
+        ) {}
+
         public BazaarRow(String id, String prefix, int prefixColor, String text, String rightText, int rightColor,
                     int statusColor, List<Component> tooltip, Consumer<Boolean> clickAction) {
             this(id, prefix, prefixColor, text, rightText, rightColor, statusColor, tooltip, clickAction, false, 0);

--- a/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/BazaarData.java
@@ -27,6 +27,7 @@ public class BazaarData {
     private final List<Consumer<MarketSnapshot>> listeners = new ArrayList<>();
     private final ConversionIndexService conversionIndexService;
     private Map<String, Product> lastProducts = Collections.emptyMap();
+    private long marketRevision;
 
     public BazaarData() {
         this(new ConversionIndexService());
@@ -123,10 +124,19 @@ public class BazaarData {
         this.conversionIndexService.addConversionEventListener(listener);
     }
 
+    public long marketRevision() {
+        return this.marketRevision;
+    }
+
+    public long indexRevision() {
+        return this.conversionIndexService.indexRevision();
+    }
+
     public void onUpdate(Map<String, Product> products) {
         this.lastProducts = Collections.unmodifiableMap(new LinkedHashMap<>(
             products == null ? Map.of() : products
         ));
+        this.marketRevision++;
         var snapshot = this.currentSnapshot();
 
         for (var listener : this.listeners) {

--- a/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexService.java
+++ b/src/main/java/com/github/lutzluca/btrbz/data/conversions/ConversionIndexService.java
@@ -132,6 +132,10 @@ public final class ConversionIndexService {
         return this.currentIndex;
     }
 
+    public long indexRevision() {
+        return this.indexRevision;
+    }
+
     public Optional<IndexedProduct> productById(String productId) {
         if (productId == null || productId.isBlank()) {
             return Optional.empty();

--- a/src/main/java/com/github/lutzluca/btrbz/utils/ScreenInfoHelper.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/ScreenInfoHelper.java
@@ -32,6 +32,7 @@ public final class ScreenInfoHelper {
     private boolean hasInventoryOwner = false;
     private long screenTransitionVersion = 0;
     private long dispatchedScreenTransitionVersion = 0;
+    private long inventoryVersion = 0;
     
     @Getter
     private volatile @NotNull ScreenInfo currInfo = new ScreenInfo(null);
@@ -87,6 +88,10 @@ public final class ScreenInfoHelper {
         return player != null && player.containerMenu.containerId == containerId;
     }
 
+    public long inventoryVersion() {
+        return this.inventoryVersion;
+    }
+
     private void setupInventoryWatcher() {
         this.inventoryWatcher.setOnOpen(_ -> {
             this.inventoryOwnerInfo.setScreen(this.currInfo.getScreen());
@@ -97,6 +102,7 @@ public final class ScreenInfoHelper {
             var screenInfo = this.hasInventoryOwner ? this.inventoryOwnerInfo : this.currInfo;
 
             screenInfo.markInventoryLoaded();
+            this.inventoryVersion++;
             if (screenInfo != this.currInfo && screenInfo.getScreen() == this.currInfo.getScreen()) {
                 this.currInfo.markInventoryLoaded();
             }

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetDataTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/data/OrdersWidgetDataTest.java
@@ -26,7 +26,7 @@ class OrdersWidgetDataTest {
         ));
         var data = new OrdersWidgetData(market, manager, null);
 
-        assertEquals(2, data.snapshot().filledOrderCount());
+        assertEquals(2, data.computeSnapshot().filledOrderCount());
     }
 
     @Nested


### PR DESCRIPTION
Reduces render thread allocation time from ~24% to ~10%

**Changes**
Added a central cache in WidgetHost.prepare(), WidgetDefinition gets an optional cacheKey, when it is present and equal to the last frame's value, it returns the cached result.
Implemented cacheKey in all the widgets.
Added per-row draw caches in tracked orders, bookmark and order book/price so measurement happens on data changes instead of every frame.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved widget rendering efficiency by reusing unchanged data, layouts, and prepared views.
  * Reduced unnecessary updates for order rows, tracked orders, and widget sessions.
  * Improved handling of Bazaar Orders, order books, bookmarks, presets, price differences, and daily limits.

* **Bug Fixes**
  * Widget displays now refresh more reliably when market, inventory, order, or configuration data changes.
  * Improved row layout, status indicators, tooltips, and overflow handling.

* **Tests**
  * Updated widget data tests to reflect the latest snapshot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->