### PR TITLE
fix: ignore virtual slots during item projection

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
@@ -55,6 +55,6 @@ public abstract class SlotItemProjectionMixin {
         var slots = containerScreen.getMenu().slots;
         int idx = slot.index;
 
-        return idx < slots.size() && slots.get(idx) == slot;
+        return idx >= 0 && idx < slots.size() && slots.get(idx) == slot;
     }
 }


### PR DESCRIPTION
Fixes #60
Fixes #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where negative slot indices could be incorrectly treated as active menu slots.
  * Improved menu slot validation to prevent invalid slot access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->