### PR TITLE
fix: address widget system review follow-ups

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
@@ -4,7 +4,6 @@ import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetRegistry;
-import com.github.lutzluca.btrbz.core.widgets.config.WidgetsConfig;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.ButtonOption;
 import dev.isxander.yacl3.api.Option;
@@ -59,7 +58,7 @@ public class ConfigScreen {
         var widgetBuilder = ConfigCategory.createBuilder()
             .name(Component.literal("Widgets"))
             .tooltip(Component.literal("Configure BtrBz widgets and the Widget Manager."))
-            .options(widgetManagerOptions(config.widgets))
+            .options(widgetManagerOptions())
             .options(widgetOptions(BtrBz.widgetRuntime().registry()));
         var widgets = widgetBuilder.build();
 
@@ -107,17 +106,8 @@ public class ConfigScreen {
             .toList();
     }
 
-    static List<Option<?>> widgetManagerOptions(WidgetsConfig config) {
+    static List<Option<?>> widgetManagerOptions() {
         var widgetRuntime = BtrBz.widgetRuntime();
-
-        var showLauncher = Option.<Boolean>createBuilder()
-            .name(Component.literal("Show Widget Manager Button in Bazaar"))
-            .description(createDescription(
-                "Show the draggable quick-access button in Bazaar screens. This does not disable the widget manager."
-            ))
-            .binding(true, () -> config.managerLauncherVisible, value -> config.managerLauncherVisible = value)
-            .controller(ConfigScreen::createBooleanController)
-            .build();
 
         var openManager = ButtonOption.createBuilder()
             .name(Component.literal("Open Widget Manager"))
@@ -140,7 +130,7 @@ public class ConfigScreen {
             .action((_, _) -> widgetRuntime.stateStore().resetManagerLauncherPosition(true))
             .build();
 
-        return List.of(showLauncher, openManager, resetPosition);
+        return List.of(openManager, resetPosition);
     }
 
     private static ButtonOption widgetOption(WidgetDefinition<?, ?, ?> definition) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BazaarBookmarkRowComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BazaarBookmarkRowComponent.java
@@ -115,7 +115,7 @@ final class BazaarBookmarkRowComponent extends BaseParentUIComponent {
             return true;
         }
 
-        if (click.button() == InputConstants.MOUSE_BUTTON_RIGHT) {
+        if (click.button() == InputConstants.MOUSE_BUTTON_RIGHT && click.hasControlDown()) {
             this.actions.accept(new BookmarksAction.Remove(this.bookmark.productId()));
             return true;
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarksWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/bookmarks/BookmarksWidgetDefinition.java
@@ -27,7 +27,8 @@ public final class BookmarksWidgetDefinition {
         var provider = new MemoizedWidgetDataSource<>(new BookmarksWidgetData(component));
 
         return WidgetDefinition.<BookmarksWidgetData.Snapshot, BookmarksWidgetConfig, BookmarksAction>builder(ID, "Bookmarks")
-            .description("Provides quick access to bookmarked Bazaar products and marks products with active orders.")
+            .description("Provides quick access to bookmarked Bazaar products and marks products with active orders. "
+                + "Remove a bookmark with Ctrl + right-click.")
             .config(config)
             .supports(BookmarksWidgetDefinition::supportsSession)
             .visibility((data, _, _) -> !data.bookmarks().isEmpty())

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/ManagementPreviewComponent.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/ManagementPreviewComponent.java
@@ -117,6 +117,10 @@ final class ManagementPreviewComponent extends BaseUIComponent {
             this.dragMoved = true;
         }
 
+        if (!this.dragMoved) {
+            return true;
+        }
+
         int localDropX = (int) Math.round(absoluteMouseX - this.dragState.pointerOffsetX() - this.canvas.x());
         int localDropY = (int) Math.round(absoluteMouseY - this.dragState.pointerOffsetY() - this.canvas.y());
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
@@ -421,11 +421,6 @@ public class WidgetManagementScreen extends BaseOwoScreen<FlowLayout> {
             return true;
         }
 
-        if (input.key() == InputConstants.KEY_B && !input.hasControlDown() && !input.hasAltDown()) {
-            this.setSidebarMinimized(!this.sidebarMinimized);
-            return true;
-        }
-
         return super.keyPressed(input);
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/ui/WidgetScrollContainer.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/ui/WidgetScrollContainer.java
@@ -7,6 +7,7 @@ import io.wispforest.owo.ui.core.OwoUIGraphics;
 import io.wispforest.owo.ui.core.Size;
 import io.wispforest.owo.ui.core.Sizing;
 import io.wispforest.owo.ui.core.UIComponent;
+import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -95,6 +96,12 @@ public final class WidgetScrollContainer<C extends UIComponent> extends ScrollCo
     @Override
     public boolean canFocus(FocusSource source) {
         return this.interactive && super.canFocus(source);
+    }
+
+    @Override
+    public boolean onKeyPress(KeyEvent input) {
+        // Runtime widget lists use pointer scrolling; leave keyboard input to the host screen.
+        return false;
     }
 
     @Override

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
@@ -110,6 +110,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
     private void onKeyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         if (this.btrbz$widgetHost().keyPressed(event)) {
             cir.setReturnValue(true);
         }
@@ -117,6 +121,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "mouseScrolled", at = @At("HEAD"), cancellable = true)
     private void onMouseScrolled(double mouseX, double mouseY, double hAmt, double vAmt, CallbackInfoReturnable<Boolean> cir) {
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         if (this.btrbz$widgetHost().mouseScrolled(mouseX, mouseY, hAmt, vAmt)) {
             cir.setReturnValue(true);
         }
@@ -124,6 +132,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
     private void onMouseClicked(MouseButtonEvent event, boolean doubleClick, CallbackInfoReturnable<Boolean> cir) {
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         if (this.btrbz$managerLauncher().mouseClicked(event)
             || this.btrbz$widgetHost().mouseClicked(event, doubleClick)) {
             cir.setReturnValue(true);
@@ -132,6 +144,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "mouseReleased", at = @At("HEAD"), cancellable = true)
     private void onMouseReleased(MouseButtonEvent event, CallbackInfoReturnable<Boolean> cir) {
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         var client = Minecraft.getInstance();
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight()
@@ -144,6 +160,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "mouseDragged", at = @At("HEAD"), cancellable = true)
     private void onMouseDragged(MouseButtonEvent event, double deltaX, double deltaY, CallbackInfoReturnable<Boolean> cir) {
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         var client = Minecraft.getInstance();
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight()

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
@@ -60,6 +60,12 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
 
     @Inject(method = "extractRenderState", at = @At("TAIL"))
     private void onRender(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        // Only Bazaar containers can host screen widgets. Rendering this host for other containers
+        // would alternate the shared session provider between screen and HUD contexts every frame.
+        if (!ScreenInfoHelper.inBazaar()) {
+            return;
+        }
+
         var client = Minecraft.getInstance();
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight()

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
@@ -6,7 +6,6 @@ import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
-import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -20,16 +19,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 // never dispatches to this bytecode, so these injections never run for those screens.
 @Mixin(ContainerEventHandler.class)
 public interface ContainerEventHandlerMixin {
-
-    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
-    private void onKeyPressed(KeyEvent event, CallbackInfoReturnable<Boolean> cir) {
-        if (Minecraft.getInstance().screen instanceof SignEditScreen
-            && Minecraft.getInstance().screen instanceof WidgetHostOwner owner
-            && owner.btrbz$widgetHost().keyPressed(event)) {
-            cir.setReturnValue(true);
-        }
-    }
-
     @Inject(method = "mouseScrolled", at = @At("HEAD"), cancellable = true)
     private void onMouseScrolled(double mouseX, double mouseY, double hAmt, double vAmt,
             CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/MinecraftClientMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/MinecraftClientMixin.java
@@ -1,5 +1,6 @@
 package com.github.lutzluca.btrbz.mixin;
 
+import com.github.lutzluca.btrbz.core.widgets.manager.WidgetManagementScreen;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
 import net.minecraft.client.gui.screens.Screen;
 import org.jetbrains.annotations.Nullable;
@@ -39,11 +40,21 @@ public abstract class MinecraftClientMixin {
     // @formatter:on
     @Inject(method = "setScreen(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At("HEAD"))
     private void onSetScreenHead(@Nullable Screen screen, CallbackInfo ci) {
+        // The manager temporarily replaces its parent screen. Excluding it preserves the Bazaar
+        // predecessor that sign widgets need when returning to the same sign instance.
+        if (screen instanceof WidgetManagementScreen) {
+            return;
+        }
+
         ScreenInfoHelper.get().setScreen(screen);
     }
 
     @Inject(method = "setScreen(Lnet/minecraft/client/gui/screens/Screen;)V", at = @At("TAIL"))
     private void onSetScreenTail(@Nullable Screen screen, CallbackInfo ci) {
+        if (screen instanceof WidgetManagementScreen) {
+            return;
+        }
+
         ScreenInfoHelper.get().fireScreenSwitchCallbacks();
     }
 }


### PR DESCRIPTION
## Summary

- Avoid creating screen widget sessions for unrelated container screens, preventing HUD prepared-cache invalidation every frame
- Preserve Bazaar screen history while temporarily opening Widget Manager from a sign screen
- Keep quick-access launcher visibility owned by Widget Manager so stale YACL state cannot overwrite it
- Require Ctrl+right-click when removing bookmarks
- Keep widget scrolling pointer-driven and remove redundant sign keyboard routing
- Prevent sub-threshold pointer movement from changing preview placement
- Remove the redundant Widget Manager `B` shortcut so hexadecimal color input is not intercepted

## Verification

- Confirmed Bazaar context remains available after opening and closing Widget Manager from a sign screen
- Confirmed YACL saves no longer revert quick-access launcher visibility
- Confirmed keyboard input no longer scrolls focused widget lists
- Confirmed HUD session caching remains stable in unrelated container screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget management screens no longer trigger unrelated screen updates or callbacks.
  * Widgets now render only in supported Bazaar container screens.

* **Bug Fixes**
  * Bookmarks can only be removed with Ctrl + right-click.
  * Clicking without dragging no longer moves widget placements.
  * Removed the unmodified `B` shortcut for minimizing the widget sidebar.
  * Keyboard input no longer interferes with widget scrolling or sign-edit screens.

* **UI Improvements**
  * Simplified widget manager options by removing the launcher visibility setting.
  * Updated bookmark instructions to reflect the new removal shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->