### PR TITLE
port: re-add 26.2 support

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -26,7 +26,6 @@
     <module name="TreeWalker">
         <!-- Imports stay explicit and free of dead dependencies. Ordering is intentionally not enforced -->
         <module name="AvoidStarImport"/>
-        <module name="UnusedImports"/>
 
         <!-- Structural layout: attached braces and no unbraced control flow -->
         <module name="NeedBraces"/>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id("dev.kikugie.stonecutter") version "0.9"
+    id("dev.kikugie.stonecutter") version "0.9.7"
 }
 
 stonecutter {
@@ -16,7 +16,7 @@ stonecutter {
     centralScript = "build.gradle.kts"
 
     create(rootProject) {
-        versions("26.1")
+        versions("26.1","26.2")
         vcsVersion = "26.1"
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/ProductInfoProvider.java
@@ -365,13 +365,7 @@ public final class ProductInfoProvider {
     }
 
     private void confirmAndOpen(String link) {
-        //? if <26.2 {
-        var client = Minecraft.getInstance();
-        //?} else {
-        /*var client = Minecraft.getInstance().gui;
-         *///?}
-
-        client.setScreen(new ConfirmLinkScreen(
+        GameUtils.setScreen(new ConfirmLinkScreen(
             confirmed -> {
                 if (confirmed) {
                     Try
@@ -385,7 +379,7 @@ public final class ProductInfoProvider {
                 }
 
                 var prev = ScreenInfoHelper.get().getPrevInfo();
-                client.setScreen(prev != null ? prev.getScreen() : null);
+                GameUtils.setScreen(prev != null ? prev.getScreen() : null);
             }, link, true));
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
@@ -12,7 +12,8 @@ public class WidgetCommand {
         return Commands.rootCommand.then(ClientCommands
             .literal("widgets")
             .executes(_ -> {
-                Minecraft.getInstance().schedule(() -> GameUtils.setScreen(runtime.createManagementScreen(GameUtils.screen())));
+                Minecraft.getInstance()
+                    .schedule(() -> GameUtils.setScreen(runtime.createManagementScreen(GameUtils.screen())));
                 return 1;
             }));
     }

--- a/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
@@ -1,33 +1,19 @@
 package com.github.lutzluca.btrbz.core.commands;
 
 import com.github.lutzluca.btrbz.core.widgets.WidgetRuntime;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
 import net.minecraft.client.Minecraft;
 
 public class WidgetCommand {
-
-
-    //? if <26.2 {
     public static LiteralArgumentBuilder<FabricClientCommandSource> get(WidgetRuntime runtime) {
         return Commands.rootCommand.then(ClientCommands
             .literal("widgets")
             .executes(_ -> {
-                var client = Minecraft.getInstance();
-                client.schedule(() -> client.setScreen(runtime.createManagementScreen(client.screen)));
+                Minecraft.getInstance().schedule(() -> GameUtils.setScreen(runtime.createManagementScreen(GameUtils.screen())));
                 return 1;
             }));
     }
-    //?} else {
-    /*public static LiteralArgumentBuilder<FabricClientCommandSource> get(WidgetRuntime runtime) {
-        return Commands.rootCommand.then(ClientCommands
-            .literal("widgets")
-            .executes(_ -> {
-                var client = Minecraft.getInstance();
-                client.schedule(() -> client.gui.setScreen(runtime.createManagementScreen(client.gui.screen())));
-                return 1;
-            }));
-    }
-    *///?}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/commands/WidgetCommand.java
@@ -8,6 +8,8 @@ import net.minecraft.client.Minecraft;
 
 public class WidgetCommand {
 
+
+    //? if <26.2 {
     public static LiteralArgumentBuilder<FabricClientCommandSource> get(WidgetRuntime runtime) {
         return Commands.rootCommand.then(ClientCommands
             .literal("widgets")
@@ -17,4 +19,15 @@ public class WidgetCommand {
                 return 1;
             }));
     }
+    //?} else {
+    /*public static LiteralArgumentBuilder<FabricClientCommandSource> get(WidgetRuntime runtime) {
+        return Commands.rootCommand.then(ClientCommands
+            .literal("widgets")
+            .executes(_ -> {
+                var client = Minecraft.getInstance();
+                client.schedule(() -> client.gui.setScreen(runtime.createManagementScreen(client.gui.screen())));
+                return 1;
+            }));
+    }
+    *///?}
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
@@ -4,6 +4,7 @@ import com.github.lutzluca.btrbz.BtrBz;
 import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.WidgetRegistry;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import dev.isxander.yacl3.api.ConfigCategory;
 import dev.isxander.yacl3.api.ButtonOption;
 import dev.isxander.yacl3.api.Option;
@@ -25,22 +26,12 @@ import org.jetbrains.annotations.Nullable;
 
 public class ConfigScreen {
 
-    //? if <26.2 {
     public static void open() {
         var client = Minecraft.getInstance();
-        client.schedule(() -> client.setScreen(ConfigScreen.create(
-            client.screen,
+        client.schedule(() -> GameUtils.setScreen(ConfigScreen.create(
+            GameUtils.screen(),
             ConfigManager.get())));
     }
-    //?} else {
-    /*public static void open() {
-        var client = Minecraft.getInstance();
-        client.schedule(() -> client.gui.setScreen(ConfigScreen.create(
-            client.gui.screen(),
-            ConfigManager.get()
-        )));
-    }
-    *///?}
 
     public static Screen create(Screen parent, Config config) {
         return YetAnotherConfigLib.create(
@@ -107,27 +98,15 @@ public class ConfigScreen {
     static List<Option<?>> widgetManagerOptions() {
         var widgetRuntime = BtrBz.widgetRuntime();
 
-        //? if <26.2 {
         var openManager = ButtonOption.createBuilder()
             .name(Component.literal("Open Widget Manager"))
             .text(Component.literal("Open"))
             .description(createDescription(
                 "Open the widget manager without using the Bazaar quick-access button.",
                 ConfigImages.WidgetManagerButton))
-            .action((screen, _) -> Minecraft.getInstance().setScreen(
+            .action((screen, _) -> GameUtils.setScreen(
                 widgetRuntime.createManagementScreen(screen)))
             .build();
-        //?} else {
-        /*var openManager = ButtonOption.createBuilder()
-            .name(Component.literal("Open Widget Manager"))
-            .text(Component.literal("Open"))
-            .description(createDescription(
-                "Open the widget manager without using the Bazaar quick-access button.",
-                ConfigImages.WidgetManagerButton))
-            .action((screen, _) -> Minecraft.getInstance().gui.setScreen(
-                widgetRuntime.createManagementScreen(screen)))
-            .build();
-        *///?}
 
         var resetPosition = ButtonOption.createBuilder()
             .name(Component.literal("Reset Widget Manager Button Position"))
@@ -156,23 +135,13 @@ public class ConfigScreen {
             ? createDescription(description)
             : createDescription(description, image);
 
-        //? if <26.2 {
         return ButtonOption.createBuilder()
             .name(Component.literal(name))
             .text(Component.literal("Configure"))
             .description(optionDescription)
-            .action((screen, _) -> Minecraft.getInstance().setScreen(
+            .action((screen, _) -> GameUtils.setScreen(
                 BtrBz.widgetRuntime().createManagementScreenForWidget(screen, id)))
             .build();
-        //?} else {
-        /*return ButtonOption.createBuilder()
-            .name(Component.literal(name))
-            .text(Component.literal("Configure"))
-            .description(optionDescription)
-            .action((screen, _) -> Minecraft.getInstance().gui.setScreen(
-                BtrBz.widgetRuntime().createManagementScreenForWidget(screen, id)))
-            .build();
-        *///?}
     }
 
     public static OptionDescription createDescription(String text) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/config/ConfigScreen.java
@@ -107,6 +107,7 @@ public class ConfigScreen {
     static List<Option<?>> widgetManagerOptions() {
         var widgetRuntime = BtrBz.widgetRuntime();
 
+        //? if <26.2 {
         var openManager = ButtonOption.createBuilder()
             .name(Component.literal("Open Widget Manager"))
             .text(Component.literal("Open"))
@@ -116,6 +117,17 @@ public class ConfigScreen {
             .action((screen, _) -> Minecraft.getInstance().setScreen(
                 widgetRuntime.createManagementScreen(screen)))
             .build();
+        //?} else {
+        /*var openManager = ButtonOption.createBuilder()
+            .name(Component.literal("Open Widget Manager"))
+            .text(Component.literal("Open"))
+            .description(createDescription(
+                "Open the widget manager without using the Bazaar quick-access button.",
+                ConfigImages.WidgetManagerButton))
+            .action((screen, _) -> Minecraft.getInstance().gui.setScreen(
+                widgetRuntime.createManagementScreen(screen)))
+            .build();
+        *///?}
 
         var resetPosition = ButtonOption.createBuilder()
             .name(Component.literal("Reset Widget Manager Button Position"))
@@ -144,6 +156,7 @@ public class ConfigScreen {
             ? createDescription(description)
             : createDescription(description, image);
 
+        //? if <26.2 {
         return ButtonOption.createBuilder()
             .name(Component.literal(name))
             .text(Component.literal("Configure"))
@@ -151,6 +164,15 @@ public class ConfigScreen {
             .action((screen, _) -> Minecraft.getInstance().setScreen(
                 BtrBz.widgetRuntime().createManagementScreenForWidget(screen, id)))
             .build();
+        //?} else {
+        /*return ButtonOption.createBuilder()
+            .name(Component.literal(name))
+            .text(Component.literal("Configure"))
+            .description(optionDescription)
+            .action((screen, _) -> Minecraft.getInstance().gui.setScreen(
+                BtrBz.widgetRuntime().createManagementScreenForWidget(screen, id)))
+            .build();
+        *///?}
     }
 
     public static OptionDescription createDescription(String text) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
@@ -39,11 +39,21 @@ public final class OrderBookScreen extends Screen {
         return this.productName;
     }
 
+
+    //? if <26.2 {
     @Override
     public void onClose() {
         this.host.dispose();
         Minecraft.getInstance().setScreen(this.parent);
     }
+    //?} else {
+    /*@Override
+    public void onClose() {
+        this.host.dispose();
+        Minecraft.getInstance().gui.setScreen(this.parent);
+    }
+    *///?}
+
 
     @Override
     public void removed() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
@@ -4,6 +4,7 @@ import com.github.lutzluca.btrbz.data.ProductIdentity;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHost;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOptions;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
@@ -40,19 +41,11 @@ public final class OrderBookScreen extends Screen {
     }
 
 
-    //? if <26.2 {
     @Override
     public void onClose() {
         this.host.dispose();
-        Minecraft.getInstance().setScreen(this.parent);
+        GameUtils.setScreen(this.parent);
     }
-    //?} else {
-    /*@Override
-    public void onClose() {
-        this.host.dispose();
-        Minecraft.getInstance().gui.setScreen(this.parent);
-    }
-    *///?}
 
 
     @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreen.java
@@ -5,7 +5,6 @@ import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHost;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOptions;
 import com.github.lutzluca.btrbz.utils.GameUtils;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.KeyEvent;
@@ -40,13 +39,11 @@ public final class OrderBookScreen extends Screen {
         return this.productName;
     }
 
-
     @Override
     public void onClose() {
         this.host.dispose();
         GameUtils.setScreen(this.parent);
     }
-
 
     @Override
     public void removed() {

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -77,11 +77,20 @@ public final class OrderBookScreenController {
             }
             var identity = ProductIdentity.fromIndex(product);
 
+            //? if <26.2 {
             Minecraft.getInstance().setScreen(new OrderBookScreen(
                 context.view().getCurrInfo().getScreen(),
                 identity,
                 product.formattedName(),
                 runtime.createScreenHost()));
+            //?} else {
+            /*Minecraft.getInstance().gui.setScreen(new OrderBookScreen(
+                context.view().getCurrInfo().getScreen(),
+                identity,
+                product.formattedName(),
+                runtime.createScreenHost()));
+            *///?}
+
             return SlotClickResult.Consume;
         }
     }

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -12,7 +12,6 @@ import com.github.lutzluca.btrbz.utils.slot.SlotHookRegistry;
 import com.github.lutzluca.btrbz.utils.slot.SlotRenderContext;
 import com.github.lutzluca.btrbz.utils.slot.SlotView;
 import com.github.lutzluca.btrbz.core.widgets.WidgetRuntime;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/orderbook/OrderBookScreenController.java
@@ -3,6 +3,7 @@ package com.github.lutzluca.btrbz.core.orderbook;
 import com.github.lutzluca.btrbz.core.ProductInfoProvider;
 import com.github.lutzluca.btrbz.core.config.ConfigManager;
 import com.github.lutzluca.btrbz.data.ProductIdentity;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper.BazaarMenuType;
 import com.github.lutzluca.btrbz.utils.slot.SlotClickContext;
 import com.github.lutzluca.btrbz.utils.slot.SlotClickResult;
@@ -77,19 +78,11 @@ public final class OrderBookScreenController {
             }
             var identity = ProductIdentity.fromIndex(product);
 
-            //? if <26.2 {
-            Minecraft.getInstance().setScreen(new OrderBookScreen(
+            GameUtils.setScreen(new OrderBookScreen(
                 context.view().getCurrInfo().getScreen(),
                 identity,
                 product.formattedName(),
                 runtime.createScreenHost()));
-            //?} else {
-            /*Minecraft.getInstance().gui.setScreen(new OrderBookScreen(
-                context.view().getCurrInfo().getScreen(),
-                identity,
-                product.formattedName(),
-                runtime.createScreenHost()));
-            *///?}
 
             return SlotClickResult.Consume;
         }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.hud;
 
 import com.github.lutzluca.btrbz.BtrBz;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.Notifier;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
@@ -26,16 +27,9 @@ public final class BtrBzWidgetKeybinds {
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (toggleHud.consumeClick()) {
-
-                //? if <26.2 {
-                if (client.screen != null || client.player == null || client.level == null) {
+                if (GameUtils.screen() != null || client.player == null || client.level == null) {
                     continue;
                 }
-                //?} else {
-                /*if (client.gui.screen() != null || client.player == null || client.level == null) {
-                    continue;
-                }
-                *///?}
 
                 var definition = BtrBz.widgetRuntime().registry()
                     .find(BazaarOrdersWidgetDefinition.ID)

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
@@ -26,9 +26,16 @@ public final class BtrBzWidgetKeybinds {
 
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (toggleHud.consumeClick()) {
+
+                //? if <26.2 {
                 if (client.screen != null || client.player == null || client.level == null) {
                     continue;
                 }
+                //?} else {
+                /*if (client.gui.screen() != null || client.player == null || client.level == null) {
+                    continue;
+                }
+                *///?}
 
                 var definition = BtrBz.widgetRuntime().registry()
                     .find(BazaarOrdersWidgetDefinition.ID)

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
@@ -20,6 +20,7 @@ public final class HudWidgetBridge {
         });
     }
 
+    //? if <26.2 {
     private static void render(WidgetHost host, GuiGraphicsExtractor graphics, float partialTicks) {
         var client = Minecraft.getInstance();
         if (shouldSuppressHud(
@@ -47,6 +48,36 @@ public final class HudWidgetBridge {
             WidgetHostOptions.runtime(false),
             null);
     }
+    //?} else {
+    /*private static void render(WidgetHost host, GuiGraphicsExtractor graphics, float partialTicks) {
+        var client = Minecraft.getInstance();
+        if (shouldSuppressHud(
+            client.gui.hud.isHidden(),
+            client.options.keyPlayerList.isDown(),
+            client.getDebugOverlay().showDebugScreen(),
+            client.level == null)) {
+            return;
+        }
+
+        boolean generalContainer = client.gui.screen() instanceof AbstractContainerScreen<?>
+            && !ScreenInfoHelper.inBazaar();
+
+        if (client.gui.screen() != null && !(client.gui.screen() instanceof ChatScreen) && !generalContainer) {
+            return;
+        }
+
+        var window = client.getWindow();
+        host.render(
+            graphics,
+            -1,
+            -1,
+            partialTicks,
+            new WidgetCanvas(0, 0, window.getGuiScaledWidth(), window.getGuiScaledHeight()),
+            WidgetHostOptions.runtime(false),
+            null);
+    }
+    *///?}
+
 
     static boolean shouldSuppressHud(
         boolean hideGui,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
@@ -3,6 +3,7 @@ package com.github.lutzluca.btrbz.core.widgets.hud;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHost;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOptions;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.minecraft.client.Minecraft;
@@ -20,21 +21,29 @@ public final class HudWidgetBridge {
         });
     }
 
-    //? if <26.2 {
     private static void render(WidgetHost host, GuiGraphicsExtractor graphics, float partialTicks) {
         var client = Minecraft.getInstance();
+
+        //? if <26.2 {
+        boolean hideGui = client.options.hideGui;
+        //?} else {
+        /*boolean hideGui = client.gui.hud.isHidden();
+         *///?}
+
         if (shouldSuppressHud(
-            client.options.hideGui,
+            hideGui,
             client.options.keyPlayerList.isDown(),
             client.getDebugOverlay().showDebugScreen(),
             client.level == null)) {
             return;
         }
 
-        boolean generalContainer = client.screen instanceof AbstractContainerScreen<?>
+        var screen = GameUtils.screen();
+
+        boolean generalContainer = screen instanceof AbstractContainerScreen<?>
             && !ScreenInfoHelper.inBazaar();
 
-        if (client.screen != null && !(client.screen instanceof ChatScreen) && !generalContainer) {
+        if (screen != null && !(screen instanceof ChatScreen) && !generalContainer) {
             return;
         }
 
@@ -48,36 +57,6 @@ public final class HudWidgetBridge {
             WidgetHostOptions.runtime(false),
             null);
     }
-    //?} else {
-    /*private static void render(WidgetHost host, GuiGraphicsExtractor graphics, float partialTicks) {
-        var client = Minecraft.getInstance();
-        if (shouldSuppressHud(
-            client.gui.hud.isHidden(),
-            client.options.keyPlayerList.isDown(),
-            client.getDebugOverlay().showDebugScreen(),
-            client.level == null)) {
-            return;
-        }
-
-        boolean generalContainer = client.gui.screen() instanceof AbstractContainerScreen<?>
-            && !ScreenInfoHelper.inBazaar();
-
-        if (client.gui.screen() != null && !(client.gui.screen() instanceof ChatScreen) && !generalContainer) {
-            return;
-        }
-
-        var window = client.getWindow();
-        host.render(
-            graphics,
-            -1,
-            -1,
-            partialTicks,
-            new WidgetCanvas(0, 0, window.getGuiScaledWidth(), window.getGuiScaledHeight()),
-            WidgetHostOptions.runtime(false),
-            null);
-    }
-    *///?}
-
 
     static boolean shouldSuppressHud(
         boolean hideGui,

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
@@ -13,6 +13,7 @@ import com.github.lutzluca.btrbz.core.widgets.ui.WidgetColorFormat;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetSurfaces;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetTooltips;
 import com.github.lutzluca.btrbz.core.widgets.ui.TooltipDelayState;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.wispforest.owo.ui.base.BaseOwoScreen;
 import io.wispforest.owo.ui.component.ButtonComponent;
@@ -251,17 +252,10 @@ public class WidgetManagementScreen extends BaseOwoScreen<FlowLayout> {
         this.rebuildSidebar();
     }
 
-    //? if <26.2 {
     @Override
     public void onClose() {
-        this.minecraft.setScreen(this.returnScreen());
+        GameUtils.setScreen(this.returnScreen());
     }
-    //?} else {
-    /*@Override
-    public void onClose() {
-        this.minecraft.gui.setScreen(this.returnScreen());
-    }
-    *///?}
 
 
     @Override

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
@@ -251,10 +251,18 @@ public class WidgetManagementScreen extends BaseOwoScreen<FlowLayout> {
         this.rebuildSidebar();
     }
 
+    //? if <26.2 {
     @Override
     public void onClose() {
         this.minecraft.setScreen(this.returnScreen());
     }
+    //?} else {
+    /*@Override
+    public void onClose() {
+        this.minecraft.gui.setScreen(this.returnScreen());
+    }
+    *///?}
+
 
     @Override
     public void resize(int width, int height) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagementScreen.java
@@ -257,7 +257,6 @@ public class WidgetManagementScreen extends BaseOwoScreen<FlowLayout> {
         GameUtils.setScreen(this.returnScreen());
     }
 
-
     @Override
     public void resize(int width, int height) {
         super.resize(width, height);

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagerLauncher.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagerLauncher.java
@@ -10,6 +10,7 @@ import com.github.lutzluca.btrbz.core.widgets.layout.WidgetPlacement;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetCanvasComponent;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetSlotComponent;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetSurfaces;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.wispforest.owo.ui.component.UIComponents;
 import io.wispforest.owo.ui.container.FlowLayout;
@@ -19,7 +20,6 @@ import io.wispforest.owo.ui.core.Insets;
 import io.wispforest.owo.ui.core.OwoUIAdapter;
 import io.wispforest.owo.ui.core.Sizing;
 import java.util.List;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
@@ -156,12 +156,7 @@ public final class WidgetManagerLauncher {
                 owner.btrbz$prepareManagerTransition();
             }
 
-            //? if <26.2 {
-            Minecraft.getInstance().setScreen(manager);
-            //?} else {
-            /*Minecraft.getInstance().gui.setScreen(manager);
-            *///?}
-
+            GameUtils.setScreen(manager);
         }
 
         return true;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagerLauncher.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/manager/WidgetManagerLauncher.java
@@ -156,7 +156,12 @@ public final class WidgetManagerLauncher {
                 owner.btrbz$prepareManagerTransition();
             }
 
+            //? if <26.2 {
             Minecraft.getInstance().setScreen(manager);
+            //?} else {
+            /*Minecraft.getInstance().gui.setScreen(manager);
+            *///?}
+
         }
 
         return true;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookActionHandler.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookActionHandler.java
@@ -1,6 +1,7 @@
 package com.github.lutzluca.btrbz.core.widgets.orderbook;
 
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.Utils;
 import com.github.lutzluca.btrbz.core.widgets.WidgetActionHandler;
 import net.minecraft.client.Minecraft;
@@ -24,11 +25,7 @@ public final class OrderBookActionHandler implements WidgetActionHandler<OrderBo
                     Minecraft.getInstance().keyboardHandler.setClipboard(
                         Utils.formatDecimal(select.price(), 1, false));
 
-                    //? if <26.2 {
-                    var screen = Minecraft.getInstance().screen;
-                    //?} else {
-                    /*var screen = Minecraft.getInstance().gui.screen();
-                    *///?}
+                    var screen = GameUtils.screen();
 
                     if (screen != null) {
                         screen.onClose();
@@ -42,11 +39,7 @@ public final class OrderBookActionHandler implements WidgetActionHandler<OrderBo
                     return;
                 }
 
-                //? if <26.2 {
-                var screen = Minecraft.getInstance().screen;
-                //?} else {
-                /*var screen = Minecraft.getInstance().gui.screen();
-                *///?}
+                var screen = GameUtils.screen();
 
                 if (screen != null) {
                     screen.onClose();

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookActionHandler.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/orderbook/OrderBookActionHandler.java
@@ -23,7 +23,12 @@ public final class OrderBookActionHandler implements WidgetActionHandler<OrderBo
                 if (current.inOrderBook()) {
                     Minecraft.getInstance().keyboardHandler.setClipboard(
                         Utils.formatDecimal(select.price(), 1, false));
+
+                    //? if <26.2 {
                     var screen = Minecraft.getInstance().screen;
+                    //?} else {
+                    /*var screen = Minecraft.getInstance().gui.screen();
+                    *///?}
 
                     if (screen != null) {
                         screen.onClose();
@@ -37,7 +42,11 @@ public final class OrderBookActionHandler implements WidgetActionHandler<OrderBo
                     return;
                 }
 
+                //? if <26.2 {
                 var screen = Minecraft.getInstance().screen;
+                //?} else {
+                /*var screen = Minecraft.getInstance().gui.screen();
+                *///?}
 
                 if (screen != null) {
                     screen.onClose();

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -18,6 +18,7 @@ import com.github.lutzluca.btrbz.core.widgets.layout.WidgetBounds;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetPlacement;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetScaleResolver;
 import com.github.lutzluca.btrbz.core.widgets.config.WidgetStateStore;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.wispforest.owo.ui.core.OwoUIAdapter;
 import io.wispforest.owo.ui.core.Size;
@@ -437,10 +438,7 @@ public final class WidgetHost {
             return;
         }
 
-        //? if <26.2 {
-        var current = this.currentSession(Minecraft.getInstance().screen);
-        //?} else
-        //var current = this.currentSession(Minecraft.getInstance().gui.screen());
+        var current = this.currentSession(GameUtils.screen());
 
         if (mountedWidget.preparedSessionId != current.id()
             || mountedWidget.preparedSessionContextRevision != current.contextRevision()) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -22,7 +22,6 @@ import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.wispforest.owo.ui.core.OwoUIAdapter;
 import io.wispforest.owo.ui.core.Size;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.KeyEvent;

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/runtime/WidgetHost.java
@@ -437,7 +437,10 @@ public final class WidgetHost {
             return;
         }
 
+        //? if <26.2 {
         var current = this.currentSession(Minecraft.getInstance().screen);
+        //?} else
+        //var current = this.currentSession(Minecraft.getInstance().gui.screen());
 
         if (mountedWidget.preparedSessionId != current.id()
             || mountedWidget.preparedSessionContextRevision != current.contextRevision()) {

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
@@ -80,17 +80,10 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight());
 
-        //? if <26.2 {
         this.btrbz$widgetHost().render(
             graphics, mouseX, mouseY, delta,
             canvas,
-            WidgetHostOptions.runtime(true), client.screen);
-        //?} else {
-        /*this.btrbz$widgetHost().render(
-            graphics, mouseX, mouseY, delta,
-            canvas,
-            WidgetHostOptions.runtime(true), client.gui.screen());
-        *///?}
+            WidgetHostOptions.runtime(true), GameUtils.screen());
 
         this.btrbz$managerLauncher().render(
             graphics, mouseX, mouseY, delta, canvas, (Screen) (Object) this);

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractContainerScreenMixin.java
@@ -79,10 +79,19 @@ public abstract class AbstractContainerScreenMixin implements WidgetHostOwner, W
         var client = Minecraft.getInstance();
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight());
+
+        //? if <26.2 {
         this.btrbz$widgetHost().render(
             graphics, mouseX, mouseY, delta,
             canvas,
             WidgetHostOptions.runtime(true), client.screen);
+        //?} else {
+        /*this.btrbz$widgetHost().render(
+            graphics, mouseX, mouseY, delta,
+            canvas,
+            WidgetHostOptions.runtime(true), client.gui.screen());
+        *///?}
+
         this.btrbz$managerLauncher().render(
             graphics, mouseX, mouseY, delta, canvas, (Screen) (Object) this);
     }

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractSignEditScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractSignEditScreenMixin.java
@@ -8,6 +8,7 @@ import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOwner;
 import com.github.lutzluca.btrbz.core.widgets.manager.SignEditScreenTransitionState;
 import com.github.lutzluca.btrbz.core.widgets.manager.WidgetManagerLauncher;
 import com.github.lutzluca.btrbz.core.widgets.manager.WidgetManagerLauncherOwner;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.AbstractSignEditScreen;
@@ -79,17 +80,10 @@ public abstract class AbstractSignEditScreenMixin implements WidgetHostOwner, Wi
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight());
 
-        //? if <26.2 {
         this.btrbz$widgetHost().render(
             graphics, mouseX, mouseY, delta,
             canvas,
-            WidgetHostOptions.runtime(true), client.screen);
-        //?} else {
-        /*this.btrbz$widgetHost().render(
-            graphics, mouseX, mouseY, delta,
-            canvas,
-            WidgetHostOptions.runtime(true), client.gui.screen());
-        *///?}
+            WidgetHostOptions.runtime(true), GameUtils.screen());
 
         this.btrbz$managerLauncher().render(
             graphics, mouseX, mouseY, delta, canvas, (net.minecraft.client.gui.screens.Screen) (Object) this);

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractSignEditScreenMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/AbstractSignEditScreenMixin.java
@@ -78,10 +78,19 @@ public abstract class AbstractSignEditScreenMixin implements WidgetHostOwner, Wi
         var client = Minecraft.getInstance();
         var canvas = new WidgetCanvas(
             0, 0, client.getWindow().getGuiScaledWidth(), client.getWindow().getGuiScaledHeight());
+
+        //? if <26.2 {
         this.btrbz$widgetHost().render(
             graphics, mouseX, mouseY, delta,
             canvas,
             WidgetHostOptions.runtime(true), client.screen);
+        //?} else {
+        /*this.btrbz$widgetHost().render(
+            graphics, mouseX, mouseY, delta,
+            canvas,
+            WidgetHostOptions.runtime(true), client.gui.screen());
+        *///?}
+
         this.btrbz$managerLauncher().render(
             graphics, mouseX, mouseY, delta, canvas, (net.minecraft.client.gui.screens.Screen) (Object) this);
     }

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
@@ -28,11 +28,20 @@ public interface ContainerEventHandlerMixin {
         double vAmt,
         CallbackInfoReturnable<Boolean> cir
     ) {
+
+        //? if <26.2 {
         if (Minecraft.getInstance().screen instanceof SignEditScreen
             && Minecraft.getInstance().screen instanceof WidgetHostOwner owner
             && owner.btrbz$widgetHost().mouseScrolled(mouseX, mouseY, hAmt, vAmt)) {
             cir.setReturnValue(true);
         }
+        //?} else {
+        /*if (Minecraft.getInstance().gui.screen() instanceof SignEditScreen
+            && Minecraft.getInstance().gui.screen() instanceof WidgetHostOwner owner
+            && owner.btrbz$widgetHost().mouseScrolled(mouseX, mouseY, hAmt, vAmt)) {
+            cir.setReturnValue(true);
+        }
+        *///?}
     }
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
@@ -41,6 +50,7 @@ public interface ContainerEventHandlerMixin {
         boolean doubleClick,
         CallbackInfoReturnable<Boolean> cir
     ) {
+        //? if <26.2 {
         if (Minecraft.getInstance().screen instanceof SignEditScreen
             && Minecraft.getInstance().screen instanceof WidgetHostOwner owner
             && (Minecraft.getInstance().screen instanceof WidgetManagerLauncherOwner launcherOwner
@@ -48,11 +58,25 @@ public interface ContainerEventHandlerMixin {
                 || owner.btrbz$widgetHost().mouseClicked(event, doubleClick))) {
             cir.setReturnValue(true);
         }
+        //?} else {
+        /*if (Minecraft.getInstance().gui.screen() instanceof SignEditScreen
+            && Minecraft.getInstance().gui.screen() instanceof WidgetHostOwner owner
+            && (Minecraft.getInstance().gui.screen() instanceof WidgetManagerLauncherOwner launcherOwner
+                && launcherOwner.btrbz$managerLauncher().mouseClicked(event)
+                || owner.btrbz$widgetHost().mouseClicked(event, doubleClick))) {
+            cir.setReturnValue(true);
+        }
+        *///?}
     }
 
     @Inject(method = "mouseReleased", at = @At("HEAD"), cancellable = true)
     private void onMouseReleased(MouseButtonEvent event, CallbackInfoReturnable<Boolean> cir) {
+        //? if <26.2 {
         var screen = Minecraft.getInstance().screen;
+        //?} else {
+        /*var screen = Minecraft.getInstance().gui.screen();
+        *///?}
+
         if (screen instanceof SignEditScreen
             && screen instanceof WidgetHostOwner owner
             && (screen instanceof WidgetManagerLauncherOwner launcherOwner
@@ -70,7 +94,12 @@ public interface ContainerEventHandlerMixin {
         double deltaY,
         CallbackInfoReturnable<Boolean> cir
     ) {
+        //? if <26.2 {
         var screen = Minecraft.getInstance().screen;
+        //?} else {
+        /*var screen = Minecraft.getInstance().gui.screen();
+        *///?}
+
         if (screen instanceof SignEditScreen
             && screen instanceof WidgetHostOwner owner
             && (screen instanceof WidgetManagerLauncherOwner launcherOwner

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/ContainerEventHandlerMixin.java
@@ -3,6 +3,7 @@ package com.github.lutzluca.btrbz.mixin;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOwner;
 import com.github.lutzluca.btrbz.core.widgets.manager.WidgetManagerLauncherOwner;
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
@@ -28,20 +29,13 @@ public interface ContainerEventHandlerMixin {
         double vAmt,
         CallbackInfoReturnable<Boolean> cir
     ) {
+        var screen = GameUtils.screen();
 
-        //? if <26.2 {
-        if (Minecraft.getInstance().screen instanceof SignEditScreen
-            && Minecraft.getInstance().screen instanceof WidgetHostOwner owner
+        if (screen instanceof SignEditScreen
+            && screen instanceof WidgetHostOwner owner
             && owner.btrbz$widgetHost().mouseScrolled(mouseX, mouseY, hAmt, vAmt)) {
             cir.setReturnValue(true);
         }
-        //?} else {
-        /*if (Minecraft.getInstance().gui.screen() instanceof SignEditScreen
-            && Minecraft.getInstance().gui.screen() instanceof WidgetHostOwner owner
-            && owner.btrbz$widgetHost().mouseScrolled(mouseX, mouseY, hAmt, vAmt)) {
-            cir.setReturnValue(true);
-        }
-        *///?}
     }
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
@@ -50,32 +44,20 @@ public interface ContainerEventHandlerMixin {
         boolean doubleClick,
         CallbackInfoReturnable<Boolean> cir
     ) {
-        //? if <26.2 {
-        if (Minecraft.getInstance().screen instanceof SignEditScreen
-            && Minecraft.getInstance().screen instanceof WidgetHostOwner owner
-            && (Minecraft.getInstance().screen instanceof WidgetManagerLauncherOwner launcherOwner
+        var screen = GameUtils.screen();
+
+        if (screen instanceof SignEditScreen
+            && screen instanceof WidgetHostOwner owner
+            && (screen instanceof WidgetManagerLauncherOwner launcherOwner
                 && launcherOwner.btrbz$managerLauncher().mouseClicked(event)
                 || owner.btrbz$widgetHost().mouseClicked(event, doubleClick))) {
             cir.setReturnValue(true);
         }
-        //?} else {
-        /*if (Minecraft.getInstance().gui.screen() instanceof SignEditScreen
-            && Minecraft.getInstance().gui.screen() instanceof WidgetHostOwner owner
-            && (Minecraft.getInstance().gui.screen() instanceof WidgetManagerLauncherOwner launcherOwner
-                && launcherOwner.btrbz$managerLauncher().mouseClicked(event)
-                || owner.btrbz$widgetHost().mouseClicked(event, doubleClick))) {
-            cir.setReturnValue(true);
-        }
-        *///?}
     }
 
     @Inject(method = "mouseReleased", at = @At("HEAD"), cancellable = true)
     private void onMouseReleased(MouseButtonEvent event, CallbackInfoReturnable<Boolean> cir) {
-        //? if <26.2 {
-        var screen = Minecraft.getInstance().screen;
-        //?} else {
-        /*var screen = Minecraft.getInstance().gui.screen();
-        *///?}
+        var screen = GameUtils.screen();
 
         if (screen instanceof SignEditScreen
             && screen instanceof WidgetHostOwner owner
@@ -94,11 +76,7 @@ public interface ContainerEventHandlerMixin {
         double deltaY,
         CallbackInfoReturnable<Boolean> cir
     ) {
-        //? if <26.2 {
-        var screen = Minecraft.getInstance().screen;
-        //?} else {
-        /*var screen = Minecraft.getInstance().gui.screen();
-        *///?}
+        var screen = GameUtils.screen();
 
         if (screen instanceof SignEditScreen
             && screen instanceof WidgetHostOwner owner

--- a/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
+++ b/src/main/java/com/github/lutzluca/btrbz/mixin/SlotItemProjectionMixin.java
@@ -1,5 +1,6 @@
 package com.github.lutzluca.btrbz.mixin;
 
+import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.slot.SlotRenderContext;
 import com.github.lutzluca.btrbz.utils.slot.SlotView;
 import org.spongepowered.asm.mixin.Mixin;
@@ -42,11 +43,7 @@ public abstract class SlotItemProjectionMixin {
 
     @Unique
     private boolean btrbz$isCurrentMenuSlot(Slot slot) {
-        //? if <26.2 {
-        var screen = Minecraft.getInstance().screen;
-        //?} else {
-        /*var screen = Minecraft.getInstance().gui.screen();
-        *///?}
+        var screen = GameUtils.screen();
 
         if (!(screen instanceof AbstractContainerScreen<?> containerScreen)) {
             return false;

--- a/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
+++ b/src/main/java/com/github/lutzluca/btrbz/utils/GameUtils.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -23,6 +24,7 @@ import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.client.gui.screens.inventory.SignEditScreen;
 import org.jetbrains.annotations.Nullable;
 import com.github.lutzluca.btrbz.core.trackedorders.TrackedOrderManager.OrderManagerConfig.QueueDisplayMode;
+import com.github.lutzluca.btrbz.mixin.AbstractSignEditScreenAccessor;
 
 @Slf4j
 public final class GameUtils {
@@ -35,19 +37,31 @@ public final class GameUtils {
      * broken by Skyblocker; {@code setScreen(null)} is used instead.</p>
      */
     public static void submitSignValue(SignEditScreen signEditScreen, String value) {
-        var accessor = (com.github.lutzluca.btrbz.mixin.AbstractSignEditScreenAccessor) signEditScreen;
+        var accessor = (AbstractSignEditScreenAccessor) signEditScreen;
         accessor.setLine(0);
         accessor.invokeSetMessage(value);
-        //? if <26.2 {
-        Minecraft.getInstance().setScreen(null);
-        //?} else {
-        /*Minecraft.getInstance().gui.setScreen(null);
-        *///?}
+        setScreen(null);
     }
 
     public static final int GLOBAL_MAX_ORDER_VOLUME = 71680;
 
     private GameUtils() {}
+
+    public static void setScreen(@Nullable Screen screen) {
+        //? if <26.2 {
+        Minecraft.getInstance().setScreen(screen);
+        //?} else {
+        /*Minecraft.getInstance().gui.setScreen(screen);
+         *///?}
+    }
+
+    public static @Nullable Screen screen() {
+        //? if <26.2 {
+        return Minecraft.getInstance().screen;
+        //?} else {
+        /*return Minecraft.getInstance().gui.screen();
+         *///?}
+    }
 
     public static String stripFormattingCodes(String text) {
         if (text == null) {

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
@@ -8,8 +8,8 @@ import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 //? if >=26.2 {
-import net.minecraft.network.chat.TextColor;
-//?}
+/*import net.minecraft.network.chat.TextColor;
+*///?}
 
 @DisplayName("Price difference widget data")
 class PriceDifferenceWidgetDataTest {

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
@@ -7,6 +7,9 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+//? if <26.2 {
+import net.minecraft.network.chat.TextColor;
+//?}
 
 @DisplayName("Price difference widget data")
 class PriceDifferenceWidgetDataTest {
@@ -28,6 +31,11 @@ class PriceDifferenceWidgetDataTest {
             Optional.empty(), 1, 1);
 
         assertEquals("Enchanted Charcoal", snapshot.productName().getString());
+
+        //? if <26.2 {
         assertEquals(ChatFormatting.GREEN.getColor(), snapshot.productName().getStyle().getColor().getValue());
+        //?} else {
+        /*assertEquals(TextColor.GREEN.getValue(), snapshot.productName().getStyle().getColor().getValue());
+        *///?}
     }
 }

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/pricedifference/PriceDifferenceWidgetDataTest.java
@@ -7,7 +7,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-//? if <26.2 {
+//? if >=26.2 {
 import net.minecraft.network.chat.TextColor;
 //?}
 

--- a/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
@@ -13,7 +13,7 @@ import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-//? if <26.2 {
+//? if >=26.2 {
 import net.minecraft.network.chat.TextColor;
 //?}
 

--- a/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 //? if >=26.2 {
-import net.minecraft.network.chat.TextColor;
-//?}
+/*import net.minecraft.network.chat.TextColor;
+*///?}
 
 class UtilsTest {
 
@@ -295,7 +295,7 @@ class UtilsTest {
             assertEquals("Thunderlord VII", text.getString());
             //? if <26.2 {
             assertEquals(ChatFormatting.LIGHT_PURPLE.getColor(), text.getStyle().getColor().getValue());
-             //?} else {
+            //?} else {
             /*assertEquals(TextColor.LIGHT_PURPLE.getValue(), text.getStyle().getColor().getValue());
             *///?}
             assertTrue(text.getStyle().isBold());

--- a/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/test/UtilsTest.java
@@ -13,6 +13,9 @@ import net.minecraft.network.chat.Component;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+//? if <26.2 {
+import net.minecraft.network.chat.TextColor;
+//?}
 
 class UtilsTest {
 
@@ -290,7 +293,11 @@ class UtilsTest {
             var text = Utils.legacyFormattedComponent("§d§lThunderlord VII");
 
             assertEquals("Thunderlord VII", text.getString());
+            //? if <26.2 {
             assertEquals(ChatFormatting.LIGHT_PURPLE.getColor(), text.getStyle().getColor().getValue());
+             //?} else {
+            /*assertEquals(TextColor.LIGHT_PURPLE.getValue(), text.getStyle().getColor().getValue());
+            *///?}
             assertTrue(text.getStyle().isBold());
             assertEquals("§d§lThunderlord VII", Utils.legacyFormattedText(text));
         }

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,0 +1,7 @@
+mc_version=26.2
+modrinth_minecraft_version_end=26.2
+fabric_version=0.158.0+26.2
+yacl_version=3.9.6+26.2-fabric
+owo_version=0.13.1+26.2
+modmenu_version=20.0.1
+release_type=alpha

--- a/versions/26.2/log4j-dev.xml
+++ b/versions/26.2/log4j-dev.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration name="BtrBz">
+  <Loggers>
+
+    <Logger additivity="true" level="${sys:btrbz.productResolver.log.level:-warn}"
+      name="com.github.lutzluca.btrbz.data.conversions.ProductResolver"/>
+
+    <Logger additivity="true" level="${sys:btrbz.log.level:-debug}"
+      name="com.github.lutzluca.btrbz"/>
+
+    <Logger additivity="false" level="warn" name="YetAnotherConfigLib">
+      <AppenderRef ref="SysOut"/>
+    </Logger>
+
+    <Logger additivity="false" level="warn" name="net.minecraft">
+      <AppenderRef ref="DebugFile"/>
+    </Logger>
+
+    <Logger additivity="false" level="warn" name="com.mojang">
+      <AppenderRef ref="DebugFile"/>
+    </Logger>
+
+    <Root level="info">
+      <AppenderRef ref="SysOut"/>
+    </Root>
+
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR re-adds support for 26.2 with owo.

**Changes:**
- Bumped stonecutter version to 0.9.7.
- Re-added 26.2 build path via stonecutter.
- Added new stonecutter branches for the owo widget code.
- Added screen helpers to `GameUtils` and used them to reduce overall stonecutter usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Minecraft 26.2.
  * Improved compatibility across supported game versions.
* **Bug Fixes**
  * Improved screen navigation and transitions throughout configuration, widget, order book, and sign interfaces.
  * Improved HUD and widget interaction handling across screens.
* **Chores**
  * Updated development logging and version-specific configuration.
  * Adjusted color handling for newer game versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->