### PR TITLE
fix: explain how to disable Bazaar HUD

### DIFF
--- a/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
+++ b/src/main/java/com/github/lutzluca/btrbz/BtrBz.java
@@ -25,6 +25,7 @@ import com.github.lutzluca.btrbz.core.widgets.pricedifference.PriceDifferenceWid
 import com.github.lutzluca.btrbz.core.widgets.trackedorders.TrackedOrdersWidgetDefinition;
 import com.github.lutzluca.btrbz.core.widgets.data.OrdersWidgetData;
 import com.github.lutzluca.btrbz.core.widgets.hud.BazaarOrdersWidgetDefinition;
+import com.github.lutzluca.btrbz.core.widgets.hud.BazaarHudHintController;
 import com.github.lutzluca.btrbz.core.widgets.hud.BtrBzWidgetKeybinds;
 import com.github.lutzluca.btrbz.core.widgets.bookmarks.BookmarkComponent;
 import com.github.lutzluca.btrbz.core.widgets.dailylimit.DailyLimitComponent;
@@ -178,8 +179,11 @@ public class BtrBz implements ClientModInitializer {
         var ordersWidgetData = new MemoizedWidgetDataSource<>(new OrdersWidgetData(
             BAZAAR_DATA, this.orderManager, this.tooltipProvider));
         var orderBookWidgetData = new MemoizedWidgetDataSource<>(new OrderBookWidgetData(BAZAAR_DATA));
+        var toggleHudKey = BtrBzWidgetKeybinds.registerMapping();
+        var bazaarOrdersWidget = BazaarOrdersWidgetDefinition.create(
+            ordersWidgetData, toggleHudKey::getTranslatedKeyMessage);
         var widgetRegistry = new WidgetRegistry();
-        widgetRegistry.register(BazaarOrdersWidgetDefinition.create(ordersWidgetData));
+        widgetRegistry.register(bazaarOrdersWidget);
         widgetRegistry.register(TrackedOrdersWidgetDefinition.create(ordersWidgetData, this.orderManager));
         widgetRegistry.register(OrderValueWidgetDefinition.create(orderValue));
         widgetRegistry.register(OrderBookWidgetDefinition.create(orderBookWidgetData, orderBookPrice));
@@ -188,13 +192,20 @@ public class BtrBz implements ClientModInitializer {
         widgetRegistry.register(OrderPresetsWidgetDefinition.create(orderPresets));
         widgetRegistry.register(DailyLimitWidgetDefinition.create(dailyLimit));
         widgetRegistry.register(PriceDifferenceWidgetDefinition.create(BAZAAR_DATA));
-        this.widgetRuntime = new WidgetRuntime(widgetRegistry, new WidgetStateStore(), sessionProvider);
+        var widgetStateStore = new WidgetStateStore();
+        this.widgetRuntime = new WidgetRuntime(widgetRegistry, widgetStateStore, sessionProvider);
+        var hudHint = new BazaarHudHintController(
+            bazaarOrdersWidget.getConfigHandle(),
+            toggleHudKey::getTranslatedKeyMessage,
+            ConfigManager::save);
         HudWidgetBridge.register(
             Identifier.fromNamespaceAndPath(MOD_ID, "widgets_hud"),
-            this.widgetRuntime.createHudHost());
+            this.widgetRuntime.createHudHost(),
+            hudHint::onWidgetRendered);
         new OrderBookScreenController(productInfoProvider, this.widgetRuntime);
         Commands.registerAll(BAZAAR_DATA, this.widgetRuntime);
-        BtrBzWidgetKeybinds.register();
+        BtrBzWidgetKeybinds.registerHandler(
+            toggleHudKey, bazaarOrdersWidget, widgetStateStore, hudHint::dismiss);
 
         this.orderManager.afterOrderSync((unfilledOrders, filledOrder) -> {
             var trackedOrders = this.orderManager.getTrackedOrders();

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarHudHintController.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarHudHintController.java
@@ -1,0 +1,63 @@
+package com.github.lutzluca.btrbz.core.widgets.hud;
+
+import com.github.lutzluca.btrbz.core.widgets.WidgetId;
+import com.github.lutzluca.btrbz.core.widgets.config.WidgetConfigHandle;
+import com.github.lutzluca.btrbz.utils.Notifier;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+
+/** Persists the Bazaar HUD hint lifecycle and emits its one-time chat message. */
+public final class BazaarHudHintController {
+    private final WidgetConfigHandle<BazaarOrdersWidgetConfig> config;
+    private final Supplier<Component> toggleKeyLabel;
+    private final Runnable saveAction;
+    private final Consumer<Component> notification;
+
+    public BazaarHudHintController(
+        WidgetConfigHandle<BazaarOrdersWidgetConfig> config,
+        Supplier<Component> toggleKeyLabel,
+        Runnable saveAction
+    ) {
+        this(config, toggleKeyLabel, saveAction, message -> Notifier.notifyPlayer(message));
+    }
+
+    BazaarHudHintController(
+        WidgetConfigHandle<BazaarOrdersWidgetConfig> config,
+        Supplier<Component> toggleKeyLabel,
+        Runnable saveAction,
+        Consumer<Component> notification
+    ) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.toggleKeyLabel = Objects.requireNonNull(toggleKeyLabel, "toggleKeyLabel");
+        this.saveAction = Objects.requireNonNull(saveAction, "saveAction");
+        this.notification = Objects.requireNonNull(notification, "notification");
+    }
+
+    public void onWidgetRendered(WidgetId id) {
+        if (!BazaarOrdersWidgetDefinition.ID.equals(id)
+            || this.config.current().supportedToggleHintState() != BazaarOrdersWidgetConfig.ToggleHintState.Unseen) {
+            return;
+        }
+
+        this.config.mutate("Bazaar HUD toggle hint shown",
+            value -> value.toggleHintState = BazaarOrdersWidgetConfig.ToggleHintState.Shown);
+        this.saveAction.run();
+        this.notification.accept(Notifier.prefix()
+            .append(Component.translatable(
+                "message.btrbz.bazaar_orders_hud_hint",
+                this.toggleKeyLabel.get()).withStyle(ChatFormatting.GRAY)));
+    }
+
+    public boolean dismiss() {
+        if (this.config.current().supportedToggleHintState() != BazaarOrdersWidgetConfig.ToggleHintState.Shown) {
+            return false;
+        }
+
+        this.config.mutate("Bazaar HUD toggle hint dismissed",
+            value -> value.toggleHintState = BazaarOrdersWidgetConfig.ToggleHintState.Dismissed);
+        return true;
+    }
+}

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetConfig.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetConfig.java
@@ -12,6 +12,10 @@ public final class BazaarOrdersWidgetConfig {
         Detailed, StatusCounts
     }
 
+    public enum ToggleHintState {
+        Unseen, Shown, Dismissed
+    }
+
     public WidgetFrameConfig frame = new WidgetFrameConfig(WidgetPlacement.topLeft(1, 0.006));
     public HudMode mode = HudMode.Detailed;
     public int visibleOrders = 4;
@@ -19,9 +23,18 @@ public final class BazaarOrdersWidgetConfig {
     public boolean abbreviateEnchanted = false;
     public boolean showQueue = true;
     public boolean showUndercutGap = false;
+    public ToggleHintState toggleHintState = ToggleHintState.Unseen;
 
     public int supportedVisibleOrders() {
         return WidgetMath.clamp(this.visibleOrders, MIN_VISIBLE_ORDERS, MAX_VISIBLE_ORDERS);
+    }
+
+    public ToggleHintState supportedToggleHintState() {
+        return this.toggleHintState == null ? ToggleHintState.Unseen : this.toggleHintState;
+    }
+
+    public boolean showToggleHint() {
+        return this.supportedToggleHintState() != ToggleHintState.Dismissed;
     }
 
     public static void resetPreferences(BazaarOrdersWidgetConfig current, BazaarOrdersWidgetConfig defaults) {

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetDefinition.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetDefinition.java
@@ -11,6 +11,8 @@ import com.github.lutzluca.btrbz.core.widgets.data.OrdersWidgetData;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetPreviewSessions;
 import com.github.lutzluca.btrbz.core.widgets.session.WidgetSession;
 import com.github.lutzluca.btrbz.core.widgets.ui.WidgetLayoutTokens;
+import java.util.function.Supplier;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
 public final class BazaarOrdersWidgetDefinition {
@@ -19,7 +21,8 @@ public final class BazaarOrdersWidgetDefinition {
     private BazaarOrdersWidgetDefinition() {}
 
     public static WidgetDefinition<BazaarWidgetViewData.OrdersData, BazaarOrdersWidgetConfig, Void> create(
-        WidgetDataSource<BazaarWidgetViewData.OrdersData> provider
+        WidgetDataSource<BazaarWidgetViewData.OrdersData> provider,
+        Supplier<Component> toggleKeyLabel
     ) {
         var config = new WidgetConfigHandle<>(ID,
             () -> ConfigManager.get().widgets.bazaarOrders, BazaarOrdersWidgetConfig::new,
@@ -35,7 +38,7 @@ public final class BazaarOrdersWidgetDefinition {
             .data(provider)
             .cachePrepared()
             .preview(() -> new WidgetPreview<>(OrdersWidgetData.preview(), WidgetPreviewSessions.hud(), "default"))
-            .viewFactory(BazaarOrdersWidgetView::new)
+            .viewFactory(() -> new BazaarOrdersWidgetView(toggleKeyLabel))
             .settingsPanel(BazaarOrdersWidgetSettings::create)
             .minSize(WidgetLayoutTokens.panelWidth(BazaarHudOptions.MINIMUM_CONTENT_WIDTH), 28)
             .build();

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetView.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetView.java
@@ -16,6 +16,7 @@ import io.wispforest.owo.ui.core.VerticalAlignment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
@@ -29,9 +30,13 @@ final class BazaarOrdersWidgetView
 
     private final Detailed detailed = new Detailed();
     private final Counts counts = new Counts();
+    private final LabelComponent toggleHint = label("", BazaarStyles.MUTED_TEXT);
+    private final Supplier<Component> toggleKeyLabel;
 
-    BazaarOrdersWidgetView() {
+    BazaarOrdersWidgetView(Supplier<Component> toggleKeyLabel) {
+        this.toggleKeyLabel = toggleKeyLabel;
         this.root.allowOverflow(true);
+        this.root.gap(WidgetLayoutTokens.SECTION_GAP);
     }
 
     @Override
@@ -55,6 +60,13 @@ final class BazaarOrdersWidgetView
         } else {
             this.detailed.update(data, config);
             this.root.child(this.detailed.root);
+        }
+
+        if (config.showToggleHint()) {
+            this.toggleHint.text(Component.translatable(
+                "text.btrbz.bazaar_orders_hud_hint",
+                this.toggleKeyLabel.get()));
+            this.root.child(this.toggleHint);
         }
     }
 

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybinds.java
@@ -1,6 +1,8 @@
 package com.github.lutzluca.btrbz.core.widgets.hud;
 
 import com.github.lutzluca.btrbz.BtrBz;
+import com.github.lutzluca.btrbz.core.widgets.WidgetDefinition;
+import com.github.lutzluca.btrbz.core.widgets.config.WidgetStateStore;
 import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.Notifier;
 import com.mojang.blaze3d.platform.InputConstants;
@@ -18,29 +20,38 @@ public final class BtrBzWidgetKeybinds {
 
     private BtrBzWidgetKeybinds() {}
 
-    public static void register() {
-        var toggleHud = KeyMappingHelper.registerKeyMapping(new KeyMapping(
+    public static KeyMapping registerMapping() {
+        return KeyMappingHelper.registerKeyMapping(new KeyMapping(
             "key.btrbz.toggle_bazaar_orders_hud",
             InputConstants.Type.KEYSYM,
             InputConstants.KEY_H,
             CATEGORY));
+    }
 
+    public static void registerHandler(
+        KeyMapping toggleHud,
+        WidgetDefinition<?, ?, ?> definition,
+        WidgetStateStore store,
+        Runnable dismissHint
+    ) {
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             while (toggleHud.consumeClick()) {
-                if (GameUtils.screen() != null || client.player == null || client.level == null) {
+                if (!canToggleHud(GameUtils.screen() != null, client.player == null, client.level == null)) {
                     continue;
                 }
 
-                var definition = BtrBz.widgetRuntime().registry()
-                    .find(BazaarOrdersWidgetDefinition.ID)
-                    .orElseThrow();
-                var store = BtrBz.widgetRuntime().stateStore();
                 boolean enabled = !store.isActive(definition);
 
-                store.setActive(definition, enabled);
+                store.setActive(definition, enabled, false);
+                dismissHint.run();
+                store.save();
                 Notifier.notifyPlayer(Notifier.prefix().append(Component.literal(
                     "Bazaar Orders HUD " + (enabled ? "enabled" : "disabled")).withStyle(ChatFormatting.GRAY)));
             }
         });
+    }
+
+    static boolean canToggleHud(boolean screenOpen, boolean playerMissing, boolean levelMissing) {
+        return !screenOpen && !playerMissing && !levelMissing;
     }
 }

--- a/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
+++ b/src/main/java/com/github/lutzluca/btrbz/core/widgets/hud/HudWidgetBridge.java
@@ -1,10 +1,12 @@
 package com.github.lutzluca.btrbz.core.widgets.hud;
 
 import com.github.lutzluca.btrbz.core.widgets.layout.WidgetCanvas;
+import com.github.lutzluca.btrbz.core.widgets.WidgetId;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHost;
 import com.github.lutzluca.btrbz.core.widgets.runtime.WidgetHostOptions;
 import com.github.lutzluca.btrbz.utils.GameUtils;
 import com.github.lutzluca.btrbz.utils.ScreenInfoHelper;
+import java.util.function.Consumer;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -15,13 +17,18 @@ import net.minecraft.resources.Identifier;
 public final class HudWidgetBridge {
     private HudWidgetBridge() {}
 
-    public static void register(Identifier elementId, WidgetHost host) {
+    public static void register(Identifier elementId, WidgetHost host, Consumer<WidgetId> renderedWidget) {
         HudElementRegistry.addLast(elementId, (context, tickCounter) -> {
-            render(host, context, tickCounter.getGameTimeDeltaPartialTick(false));
+            render(host, context, tickCounter.getGameTimeDeltaPartialTick(false), renderedWidget);
         });
     }
 
-    private static void render(WidgetHost host, GuiGraphicsExtractor graphics, float partialTicks) {
+    private static void render(
+        WidgetHost host,
+        GuiGraphicsExtractor graphics,
+        float partialTicks,
+        Consumer<WidgetId> renderedWidget
+    ) {
         var client = Minecraft.getInstance();
 
         //? if <26.2 {
@@ -48,7 +55,7 @@ public final class HudWidgetBridge {
         }
 
         var window = client.getWindow();
-        host.render(
+        var results = host.render(
             graphics,
             -1,
             -1,
@@ -56,6 +63,8 @@ public final class HudWidgetBridge {
             new WidgetCanvas(0, 0, window.getGuiScaledWidth(), window.getGuiScaledHeight()),
             WidgetHostOptions.runtime(false),
             null);
+
+        results.forEach(result -> renderedWidget.accept(result.definition().getId()));
     }
 
     static boolean shouldSuppressHud(

--- a/src/main/resources/assets/btrbz/lang/en_us.json
+++ b/src/main/resources/assets/btrbz/lang/en_us.json
@@ -1,4 +1,6 @@
 {
   "key.category.btrbz.widgets": "BtrBz Widgets",
-  "key.btrbz.toggle_bazaar_orders_hud": "Toggle Bazaar Orders HUD"
+  "key.btrbz.toggle_bazaar_orders_hud": "Toggle Bazaar Orders HUD",
+  "message.btrbz.bazaar_orders_hud_hint": "The Bazaar Orders HUD is enabled by default. Press %s to disable it. You can change this key under Controls > BtrBz Widgets.",
+  "text.btrbz.bazaar_orders_hud_hint": "Press %s to disable this HUD"
 }

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarHudHintControllerTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarHudHintControllerTest.java
@@ -1,0 +1,99 @@
+package com.github.lutzluca.btrbz.core.widgets.hud;
+
+import com.github.lutzluca.btrbz.core.widgets.WidgetId;
+import com.github.lutzluca.btrbz.core.widgets.config.WidgetConfigHandle;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Bazaar HUD hint lifecycle")
+class BazaarHudHintControllerTest {
+    @Nested
+    @DisplayName("completed renders")
+    class CompletedRenders {
+        @Test
+        @DisplayName("the first Bazaar HUD render sends and persists one message")
+        void firstBazaarRenderSendsOneMessage() {
+            var context = new TestContext();
+
+            context.controller.onWidgetRendered(WidgetId.of(
+                Identifier.fromNamespaceAndPath("btrbz", "another_widget")));
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Unseen,
+                context.config.supportedToggleHintState());
+
+            context.controller.onWidgetRendered(BazaarOrdersWidgetDefinition.ID);
+            context.controller.onWidgetRendered(BazaarOrdersWidgetDefinition.ID);
+
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Shown,
+                context.config.supportedToggleHintState());
+            assertEquals(1, context.saves.get());
+            assertEquals(1, context.messages.size());
+            assertEquals(1, context.keyReads.get());
+        }
+    }
+
+    @Nested
+    @DisplayName("dismissal")
+    class Dismissal {
+        @Test
+        @DisplayName("dismisses only after the HUD has rendered")
+        void dismissesOnlyAfterRender() {
+            var unseen = new TestContext();
+            assertFalse(unseen.controller.dismiss());
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Unseen,
+                unseen.config.supportedToggleHintState());
+
+            var shown = new TestContext();
+            shown.controller.onWidgetRendered(BazaarOrdersWidgetDefinition.ID);
+            assertTrue(shown.controller.dismiss());
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Dismissed,
+                shown.config.supportedToggleHintState());
+            assertFalse(shown.controller.dismiss());
+        }
+
+        @Test
+        @DisplayName("a dismissed hint never sends chat")
+        void dismissedHintNeverSendsChat() {
+            var context = new TestContext();
+            context.config.toggleHintState = BazaarOrdersWidgetConfig.ToggleHintState.Dismissed;
+
+            context.controller.onWidgetRendered(BazaarOrdersWidgetDefinition.ID);
+
+            assertEquals(0, context.messages.size());
+            assertEquals(0, context.saves.get());
+        }
+    }
+
+    private static final class TestContext {
+        private final BazaarOrdersWidgetConfig config = new BazaarOrdersWidgetConfig();
+        private final AtomicInteger saves = new AtomicInteger();
+        private final AtomicInteger keyReads = new AtomicInteger();
+        private final ArrayList<Component> messages = new ArrayList<>();
+        private final BazaarHudHintController controller;
+
+        private TestContext() {
+            var handle = new WidgetConfigHandle<>(
+                BazaarOrdersWidgetDefinition.ID,
+                () -> this.config,
+                BazaarOrdersWidgetConfig::new,
+                value -> value.frame,
+                BazaarOrdersWidgetConfig::resetPreferences);
+            this.controller = new BazaarHudHintController(
+                handle,
+                () -> {
+                    this.keyReads.incrementAndGet();
+                    return Component.literal("J");
+                },
+                this.saves::incrementAndGet,
+                this.messages::add);
+        }
+    }
+}

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetConfigTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BazaarOrdersWidgetConfigTest.java
@@ -4,12 +4,61 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.gson.Gson;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Bazaar orders widget config")
 class BazaarOrdersWidgetConfigTest {
+    private final Gson gson = new Gson();
+
+    @Nested
+    @DisplayName("toggle hint")
+    class ToggleHint {
+        @Test
+        @DisplayName("starts unseen for new and field-missing configs")
+        void startsUnseen() {
+            var fresh = new BazaarOrdersWidgetConfig();
+            var fieldMissing = BazaarOrdersWidgetConfigTest.this.gson.fromJson(
+                "{}", BazaarOrdersWidgetConfig.class);
+
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Unseen, fresh.supportedToggleHintState());
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Unseen, fieldMissing.supportedToggleHintState());
+            assertTrue(fresh.showToggleHint());
+
+            fresh.toggleHintState = BazaarOrdersWidgetConfig.ToggleHintState.Shown;
+            assertTrue(fresh.showToggleHint());
+        }
+
+        @Test
+        @DisplayName("round trips every persisted state")
+        void roundTripsEveryState() {
+            for (var state : BazaarOrdersWidgetConfig.ToggleHintState.values()) {
+                var config = new BazaarOrdersWidgetConfig();
+                config.toggleHintState = state;
+
+                var restored = BazaarOrdersWidgetConfigTest.this.gson.fromJson(
+                    BazaarOrdersWidgetConfigTest.this.gson.toJson(config),
+                    BazaarOrdersWidgetConfig.class);
+
+                assertEquals(state, restored.supportedToggleHintState());
+            }
+        }
+
+        @Test
+        @DisplayName("preference reset preserves dismissal")
+        void preferenceResetPreservesDismissal() {
+            var config = new BazaarOrdersWidgetConfig();
+            config.toggleHintState = BazaarOrdersWidgetConfig.ToggleHintState.Dismissed;
+
+            BazaarOrdersWidgetConfig.resetPreferences(config, new BazaarOrdersWidgetConfig());
+
+            assertEquals(BazaarOrdersWidgetConfig.ToggleHintState.Dismissed, config.supportedToggleHintState());
+            assertFalse(config.showToggleHint());
+        }
+    }
+
     @Nested
     @DisplayName("preference reset")
     class PreferenceReset {

--- a/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybindsTest.java
+++ b/src/test/java/com/github/lutzluca/btrbz/core/widgets/hud/BtrBzWidgetKeybindsTest.java
@@ -1,0 +1,19 @@
+package com.github.lutzluca.btrbz.core.widgets.hud;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Bazaar HUD keybind")
+class BtrBzWidgetKeybindsTest {
+    @Test
+    @DisplayName("accepts toggles only during normal gameplay")
+    void acceptsOnlyNormalGameplay() {
+        assertTrue(BtrBzWidgetKeybinds.canToggleHud(false, false, false));
+        assertFalse(BtrBzWidgetKeybinds.canToggleHud(true, false, false));
+        assertFalse(BtrBzWidgetKeybinds.canToggleHud(false, true, false));
+        assertFalse(BtrBzWidgetKeybinds.canToggleHud(false, false, true));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-game hint explaining how to toggle the Bazaar Orders HUD widget.
  * Displays the hint when the widget is first shown and provides a localized toggle key label.
  * Added chat notifications when the hint appears and when the HUD is enabled or disabled.
  * Hint state is saved and can be dismissed permanently.

* **Bug Fixes**
  * Restricted HUD toggling to valid gameplay states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->